### PR TITLE
feat: Initial PostgreSQL schema — users, roles, sessions, subscriptions

### DIFF
--- a/alembic/versions/0001_initial_schema.py
+++ b/alembic/versions/0001_initial_schema.py
@@ -1,0 +1,241 @@
+"""Initial schema — users, roles, sessions, subscriptions, oauth, verification tokens.
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Enums
+subscription_plan = sa.Enum(
+    "free", "trial", "researcher", "institutional", name="subscription_plan"
+)
+subscription_status = sa.Enum(
+    "active", "expired", "cancelled", "suspended", name="subscription_status"
+)
+token_type = sa.Enum(
+    "email_verification", "password_reset", "magic_link", name="token_type"
+)
+
+
+def upgrade() -> None:
+    # --- users ---
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("email_verified", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("password_hash", sa.String(255), nullable=True),
+        sa.Column("avatar_url", sa.String(512), nullable=True),
+        sa.Column("locale", sa.String(10), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    # --- roles ---
+    op.create_table(
+        "roles",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_roles_name", "roles", ["name"], unique=True)
+
+    # --- user_roles ---
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  primary_key=True),
+        sa.Column("role_id", sa.UUID(), sa.ForeignKey("roles.id", ondelete="CASCADE"),
+                  primary_key=True),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("granted_by", sa.UUID(), sa.ForeignKey("users.id", ondelete="SET NULL"),
+                  nullable=True),
+    )
+
+    # --- sessions ---
+    op.create_table(
+        "sessions",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column("user_agent", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_sessions_token_hash", "sessions", ["token_hash"], unique=True)
+    op.create_index("ix_sessions_expires_at", "sessions", ["expires_at"])
+
+    # --- subscriptions ---
+    op.create_table(
+        "subscriptions",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("plan", subscription_plan, nullable=False),
+        sa.Column("status", subscription_status, nullable=False),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    # --- verification_tokens ---
+    op.create_table(
+        "verification_tokens",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("token_hash", sa.String(255), nullable=False),
+        sa.Column("token_type", token_type, nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_verification_tokens_token_hash", "verification_tokens", ["token_hash"], unique=True
+    )
+    op.create_index(
+        "ix_verification_tokens_lookup",
+        "verification_tokens",
+        ["token_hash", "expires_at"],
+    )
+
+    # --- oauth_accounts ---
+    op.create_table(
+        "oauth_accounts",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("provider_account_id", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_oauth_accounts_provider_account",
+        "oauth_accounts",
+        ["provider", "provider_account_id"],
+        unique=True,
+    )
+
+    # --- Seed default roles ---
+    roles_table = sa.table(
+        "roles",
+        sa.column("name", sa.String),
+        sa.column("description", sa.Text),
+    )
+    op.bulk_insert(
+        roles_table,
+        [
+            {"name": "admin", "description": "Full platform administration access"},
+            {"name": "researcher", "description": "Access to research tools and datasets"},
+            {"name": "reader", "description": "Read-only access to public content"},
+            {"name": "trial", "description": "Time-limited trial access"},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("oauth_accounts")
+    op.drop_table("verification_tokens")
+    op.drop_table("subscriptions")
+    op.drop_table("sessions")
+    op.drop_table("user_roles")
+    op.drop_table("roles")
+    op.drop_table("users")
+
+    subscription_plan.drop(op.get_bind())  # type: ignore[arg-type]
+    subscription_status.drop(op.get_bind())  # type: ignore[arg-type]
+    token_type.drop(op.get_bind())  # type: ignore[arg-type]

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,129 @@
+# User Service Database Schema
+
+## Tables
+
+### users
+Core user identity table. Stores authentication credentials, profile info, and account state.
+- UUID primary key with `gen_random_uuid()`
+- `password_hash` is nullable to support OAuth-only users
+- `email` has a unique index for login lookups
+- Tracks `created_at`, `updated_at`, and `last_login_at`
+
+### roles
+Defines available authorization roles in the system.
+- Seeded with four default roles: `admin`, `researcher`, `reader`, `trial`
+- `name` is unique-indexed
+
+### user_roles
+Join table linking users to roles (many-to-many).
+- Composite primary key `(user_id, role_id)`
+- `granted_by` tracks which admin assigned the role (nullable, SET NULL on delete)
+- CASCADE delete on both user and role FKs
+
+### sessions
+Active authentication sessions with token-based lookup.
+- `token_hash` stores a hashed session token (unique index)
+- `expires_at` indexed for efficient cleanup of expired sessions
+- `revoked_at` nullable — set when session is explicitly revoked
+- CASCADE delete when user is removed
+
+### subscriptions
+User subscription/plan tracking.
+- `plan` enum: `free`, `trial`, `researcher`, `institutional`
+- `status` enum: `active`, `expired`, `cancelled`, `suspended`
+- CASCADE delete when user is removed
+
+### verification_tokens
+Short-lived tokens for email verification, password reset, and magic link login.
+- `token_type` enum: `email_verification`, `password_reset`, `magic_link`
+- `token_hash` unique-indexed for lookup
+- Composite index on `(token_hash, expires_at)` for validated lookups
+- `used_at` nullable — set when token is consumed
+- CASCADE delete when user is removed
+
+### oauth_accounts
+Links external OAuth provider accounts to internal users.
+- `provider` + `provider_account_id` has a unique composite index
+- Supports Google, GitHub, Apple, Facebook
+- CASCADE delete when user is removed
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    users {
+        uuid id PK
+        varchar email UK
+        boolean email_verified
+        varchar display_name
+        varchar password_hash
+        varchar avatar_url
+        varchar locale
+        boolean is_active
+        timestamptz created_at
+        timestamptz updated_at
+        timestamptz last_login_at
+    }
+
+    roles {
+        uuid id PK
+        varchar name UK
+        text description
+        timestamptz created_at
+    }
+
+    user_roles {
+        uuid user_id PK,FK
+        uuid role_id PK,FK
+        timestamptz granted_at
+        uuid granted_by FK
+    }
+
+    sessions {
+        uuid id PK
+        uuid user_id FK
+        varchar token_hash UK
+        varchar ip_address
+        text user_agent
+        timestamptz created_at
+        timestamptz expires_at
+        timestamptz revoked_at
+    }
+
+    subscriptions {
+        uuid id PK
+        uuid user_id FK
+        subscription_plan plan
+        subscription_status status
+        timestamptz starts_at
+        timestamptz expires_at
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    verification_tokens {
+        uuid id PK
+        uuid user_id FK
+        varchar token_hash UK
+        token_type token_type
+        timestamptz expires_at
+        timestamptz used_at
+        timestamptz created_at
+    }
+
+    oauth_accounts {
+        uuid id PK
+        uuid user_id FK
+        varchar provider
+        varchar provider_account_id
+        timestamptz created_at
+    }
+
+    users ||--o{ user_roles : "has roles"
+    roles ||--o{ user_roles : "assigned to"
+    users ||--o{ sessions : "has sessions"
+    users ||--o{ subscriptions : "has subscription"
+    users ||--o{ verification_tokens : "has tokens"
+    users ||--o{ oauth_accounts : "linked accounts"
+    users ||--o{ user_roles : "grants (granted_by)"
+```


### PR DESCRIPTION
## Summary
- Alembic migration for initial user-service schema
- 7 tables: users, roles, user_roles, sessions, subscriptions, verification_tokens, oauth_accounts
- UUID PKs, proper indexes, FK constraints, default role seeding
- Schema docs with Mermaid ER diagram

Closes noorinalabs/noorinalabs-user-service#1

## Test plan
- [ ] Migration applies cleanly against empty PostgreSQL 16
- [ ] All indexes and constraints present
- [ ] Default roles seeded
- [ ] Downgrade works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)