### PR TITLE
ops: Audit .gitignore — add Docker and production artifact patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,15 @@ htmlcov/
 # Data
 data/
 
+# Docker
+*.log
+docker-compose.override.yml
+
+# Temp / Cache
+tmp/
+temp/
+.cache/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Adds missing `.gitignore` patterns for Docker logs (`*.log`), compose overrides (`docker-compose.override.yml`), and temp/cache directories (`tmp/`, `temp/`, `.cache/`)
- Python bytecode patterns (`__pycache__/`, `*.py[cod]`) were already present — no changes needed for #25
- Verified `alembic/versions/`, `uv.lock`, and `.claude/` are NOT ignored
- No previously-tracked files required removal

Closes #25, closes #26

## Reviewer
Requestor (author): Santiago Ferreira
Requestee (reviewer): Aino Virtanen

## Test plan
- [ ] Verify new patterns appear in `.gitignore`
- [ ] Confirm `alembic/versions/` is still tracked
- [ ] Confirm `uv.lock` is still tracked
- [ ] Confirm `.claude/` directories are still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)