### PR TITLE
ops: Phase 3 scaffold stubs and migration reservation

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import context
 from src.app.config import get_settings
+import src.app.models  # ensure all models are registered
 from src.app.models.user import Base
 
 config = context.config

--- a/alembic/versions/MIGRATION_RANGES.md
+++ b/alembic/versions/MIGRATION_RANGES.md
@@ -1,0 +1,14 @@
+# Migration Sequence Reservation — Phase 3
+
+To prevent parallel branches from creating conflicting migration numbers,
+each Phase 3 issue has a reserved range:
+
+| Range     | Issue  | Feature               |
+|-----------|--------|-----------------------|
+| 0003–0009 | US #7  | Session management    |
+| 0010–0019 | US #8  | Email verification    |
+| 0020–0029 | US #9  | Subscriptions         |
+| 0030–0039 | US #10 | 2FA / TOTP            |
+
+Name your migration files with the appropriate prefix, e.g.:
+`0010_add_verification_tokens.py` for US #8.

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,7 +6,17 @@ from fastapi import FastAPI
 from src.app.database import close_db, init_db
 from src.app.middleware.cors import add_cors_middleware
 from src.app.middleware.security import add_security_headers
-from src.app.routers import auth, health, roles, sessions, users, well_known
+from src.app.routers import (
+    auth,
+    health,
+    roles,
+    sessions,
+    subscriptions,
+    totp,
+    users,
+    verification,
+    well_known,
+)
 
 
 @asynccontextmanager
@@ -32,6 +42,9 @@ def create_app() -> FastAPI:
     application.include_router(roles.router)
     application.include_router(sessions.router)
     application.include_router(well_known.router)
+    application.include_router(verification.router)
+    application.include_router(subscriptions.router)
+    application.include_router(totp.router)
 
     return application
 

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,0 +1,9 @@
+"""Import all models so Alembic autogenerate discovers them."""
+
+import src.app.models.oauth_account
+import src.app.models.role
+import src.app.models.session
+import src.app.models.subscription
+import src.app.models.totp_secret
+import src.app.models.user
+import src.app.models.verification_token  # noqa: F401

--- a/src/app/models/subscription.py
+++ b/src/app/models/subscription.py
@@ -1,0 +1,5 @@
+"""Subscription model — US #9."""
+
+# TODO: Implement Subscription model (plan, status, trial dates, Stripe refs)
+
+from src.app.models.user import Base  # noqa: F401

--- a/src/app/models/totp_secret.py
+++ b/src/app/models/totp_secret.py
@@ -1,0 +1,5 @@
+"""TOTPSecret model — US #10."""
+
+# TODO: Implement TOTPSecret model (encrypted secret, backup codes, verified flag)
+
+from src.app.models.user import Base  # noqa: F401

--- a/src/app/models/verification_token.py
+++ b/src/app/models/verification_token.py
@@ -1,0 +1,5 @@
+"""VerificationToken model — US #8."""
+
+# TODO: Implement VerificationToken model (token, purpose, expiry)
+
+from src.app.models.user import Base  # noqa: F401

--- a/src/app/routers/subscriptions.py
+++ b/src/app/routers/subscriptions.py
@@ -1,0 +1,5 @@
+"""Subscription routes — US #9."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])

--- a/src/app/routers/totp.py
+++ b/src/app/routers/totp.py
@@ -1,0 +1,5 @@
+"""TOTP routes — US #10."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/totp", tags=["totp"])

--- a/src/app/routers/verification.py
+++ b/src/app/routers/verification.py
@@ -1,0 +1,5 @@
+"""Verification routes — US #8."""
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/verification", tags=["verification"])

--- a/src/app/schemas/session.py
+++ b/src/app/schemas/session.py
@@ -1,0 +1,5 @@
+"""Session schemas — US #7."""
+
+# TODO: Implement session request/response schemas
+
+from pydantic import BaseModel  # noqa: F401

--- a/src/app/schemas/subscription.py
+++ b/src/app/schemas/subscription.py
@@ -1,0 +1,5 @@
+"""Subscription schemas — US #9."""
+
+# TODO: Implement subscription request/response schemas
+
+from pydantic import BaseModel  # noqa: F401

--- a/src/app/schemas/totp.py
+++ b/src/app/schemas/totp.py
@@ -1,0 +1,5 @@
+"""TOTP schemas — US #10."""
+
+# TODO: Implement TOTP setup/verify request/response schemas
+
+from pydantic import BaseModel  # noqa: F401

--- a/src/app/schemas/verification.py
+++ b/src/app/schemas/verification.py
@@ -1,0 +1,5 @@
+"""Verification schemas — US #8."""
+
+# TODO: Implement email verification request/response schemas
+
+from pydantic import BaseModel  # noqa: F401

--- a/src/app/services/session.py
+++ b/src/app/services/session.py
@@ -1,0 +1,3 @@
+"""Session service — US #7."""
+
+# TODO: Implement session CRUD (create, list, revoke, cleanup)

--- a/src/app/services/subscription.py
+++ b/src/app/services/subscription.py
@@ -1,0 +1,3 @@
+"""Subscription service — US #9."""
+
+# TODO: Implement subscription lifecycle (create, upgrade, cancel, trial)

--- a/src/app/services/totp.py
+++ b/src/app/services/totp.py
@@ -1,0 +1,3 @@
+"""TOTP service — US #10."""
+
+# TODO: Implement TOTP secret generation, verification, backup codes

--- a/src/app/services/verification.py
+++ b/src/app/services/verification.py
@@ -1,0 +1,3 @@
+"""Verification service — US #8."""
+
+# TODO: Implement email verification token generation and validation


### PR DESCRIPTION
## Summary

- Create empty model/schema/router/service stubs for all Phase 3 features (US #7 Sessions, #8 Email verification, #9 Subscriptions, #10 2FA/TOTP)
- Register new routers in `main.py` and import all models in `models/__init__.py` for Alembic discovery
- Reserve migration number ranges in `alembic/versions/MIGRATION_RANGES.md` to prevent sequence conflicts across parallel branches

## Why

Phase 2 taught us that parallel agents independently modifying shared files (`main.py`, `models/__init__.py`, `database.py`) causes merge conflicts. This scaffold pre-creates all stubs so each feature branch only modifies its own files.

## Migration Ranges

| Range     | Issue  | Feature               |
|-----------|--------|-----------------------|
| 0003–0009 | US #7  | Session management    |
| 0010–0019 | US #8  | Email verification    |
| 0020–0029 | US #9  | Subscriptions         |
| 0030–0039 | US #10 | 2FA / TOTP            |

## Test plan

- [x] `make lint` — only pre-existing errors (I001 in auth.py, user.py)
- [x] `make typecheck` — only pre-existing errors (oauth.py, dependencies.py)
- [ ] Verify all stub files import without error
- [ ] Verify `main.py` registers all new routers

**Requestor:** Anya Kowalczyk
**Requestee:** Idris Yusuf

🤖 Generated with [Claude Code](https://claude.com/claude-code)