### PR TITLE
fix: Use python:3.12-slim base image (3.14 breaks deps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.14-slim AS base
+FROM python:3.12-slim AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \


### PR DESCRIPTION
## Summary
- Change Dockerfile base image from python:3.14-slim to python:3.12-slim

## Root Cause
User-service container crashes on startup in production. Python 3.14 is too new for several dependencies (asyncpg, python-jose, passlib). Matches the project's `requires-python = ">=3.12"` target.

## Related Issues
Part of noorinalabs/noorinalabs-main#48

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>