### PR TITLE
fix: Resolve ruff I001, mypy errors, and add pre-commit hook

### DIFF
--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -10,9 +10,9 @@ Exit codes:
 """
 
 import json
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 
 # Load roster from shared JSON file — single source of truth for all hooks
 _ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -50,7 +50,9 @@ def main() -> None:
             "reason": (
                 "BLOCKED: git commit missing `-c user.name=` flag. "
                 "Charter § Commit Identity requires per-commit identity via -c flags. "
-                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+                'Example: git -c user.name="Kwame Asante" '
+                '-c user.email="parametrization+Kwame.Asante@gmail.com" '
+                'commit -m "..."'
             ),
         }
         print(json.dumps(result))
@@ -62,7 +64,9 @@ def main() -> None:
             "reason": (
                 "BLOCKED: git commit missing `-c user.email=` flag. "
                 "Charter § Commit Identity requires per-commit identity via -c flags. "
-                "Example: git -c user.name=\"Kwame Asante\" -c user.email=\"parametrization+Kwame.Asante@gmail.com\" commit -m \"...\""
+                'Example: git -c user.name="Kwame Asante" '
+                '-c user.email="parametrization+Kwame.Asante@gmail.com" '
+                'commit -m "..."'
             ),
         }
         print(json.dumps(result))
@@ -76,7 +80,7 @@ def main() -> None:
         result = {
             "decision": "block",
             "reason": (
-                f"BLOCKED: user.name=\"{name}\" is not a recognized roster member. "
+                f'BLOCKED: user.name="{name}" is not a recognized roster member. '
                 f"Valid names: {', '.join(sorted(ROSTER.keys()))}"
             ),
         }
@@ -88,7 +92,7 @@ def main() -> None:
         result = {
             "decision": "block",
             "reason": (
-                f"BLOCKED: user.email=\"{email}\" does not match roster for {name}. "
+                f'BLOCKED: user.email="{email}" does not match roster for {name}. '
                 f"Expected: {expected_email}"
             ),
         }

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,9 +3,9 @@ from logging.config import fileConfig
 
 from sqlalchemy.ext.asyncio import create_async_engine
 
+import src.app.models  # ensure all models are registered
 from alembic import context
 from src.app.config import get_settings
-import src.app.models  # ensure all models are registered
 from src.app.models.user import Base
 
 config = context.config

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,7 +3,7 @@ from logging.config import fileConfig
 
 from sqlalchemy.ext.asyncio import create_async_engine
 
-import src.app.models  # ensure all models are registered
+import src.app.models  # noqa: F401 — side-effect import to register models
 from alembic import context
 from src.app.config import get_settings
 from src.app.models.user import Base

--- a/alembic/versions/0001_initial_schema.py
+++ b/alembic/versions/0001_initial_schema.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-07
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "0001"

--- a/alembic/versions/0001_initial_schema.py
+++ b/alembic/versions/0001_initial_schema.py
@@ -23,9 +23,7 @@ subscription_plan = sa.Enum(
 subscription_status = sa.Enum(
     "active", "expired", "cancelled", "suspended", name="subscription_status"
 )
-token_type = sa.Enum(
-    "email_verification", "password_reset", "magic_link", name="token_type"
-)
+token_type = sa.Enum("email_verification", "password_reset", "magic_link", name="token_type")
 
 
 def upgrade() -> None:
@@ -84,18 +82,21 @@ def upgrade() -> None:
     # --- user_roles ---
     op.create_table(
         "user_roles",
-        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  primary_key=True),
-        sa.Column("role_id", sa.UUID(), sa.ForeignKey("roles.id", ondelete="CASCADE"),
-                  primary_key=True),
+        sa.Column(
+            "user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+        ),
+        sa.Column(
+            "role_id", sa.UUID(), sa.ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
+        ),
         sa.Column(
             "granted_at",
             sa.DateTime(timezone=True),
             nullable=False,
             server_default=sa.text("now()"),
         ),
-        sa.Column("granted_by", sa.UUID(), sa.ForeignKey("users.id", ondelete="SET NULL"),
-                  nullable=True),
+        sa.Column(
+            "granted_by", sa.UUID(), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+        ),
     )
 
     # --- sessions ---
@@ -107,8 +108,9 @@ def upgrade() -> None:
             primary_key=True,
             server_default=sa.text("gen_random_uuid()"),
         ),
-        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  nullable=False),
+        sa.Column(
+            "user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ),
         sa.Column("token_hash", sa.String(255), nullable=False),
         sa.Column("ip_address", sa.String(45), nullable=True),
         sa.Column("user_agent", sa.Text(), nullable=True),
@@ -133,8 +135,9 @@ def upgrade() -> None:
             primary_key=True,
             server_default=sa.text("gen_random_uuid()"),
         ),
-        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  nullable=False),
+        sa.Column(
+            "user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ),
         sa.Column("plan", subscription_plan, nullable=False),
         sa.Column("status", subscription_status, nullable=False),
         sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
@@ -162,8 +165,9 @@ def upgrade() -> None:
             primary_key=True,
             server_default=sa.text("gen_random_uuid()"),
         ),
-        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  nullable=False),
+        sa.Column(
+            "user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ),
         sa.Column("token_hash", sa.String(255), nullable=False),
         sa.Column("token_type", token_type, nullable=False),
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
@@ -193,8 +197,9 @@ def upgrade() -> None:
             primary_key=True,
             server_default=sa.text("gen_random_uuid()"),
         ),
-        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"),
-                  nullable=False),
+        sa.Column(
+            "user_id", sa.UUID(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ),
         sa.Column("provider", sa.String(50), nullable=False),
         sa.Column("provider_account_id", sa.String(255), nullable=False),
         sa.Column(

--- a/alembic/versions/0003_add_session_last_active.py
+++ b/alembic/versions/0003_add_session_last_active.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-08
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+
 from alembic import op
 
 revision: str = "0003"

--- a/alembic/versions/0030_add_totp_secrets.py
+++ b/alembic/versions/0030_add_totp_secrets.py
@@ -50,9 +50,7 @@ def upgrade() -> None:
         sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("disabled_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.create_index(
-        "ix_totp_secrets_user_id", "totp_secrets", ["user_id"], unique=True
-    )
+    op.create_index("ix_totp_secrets_user_id", "totp_secrets", ["user_id"], unique=True)
 
 
 def downgrade() -> None:

--- a/scripts/migrate_users.py
+++ b/scripts/migrate_users.py
@@ -184,9 +184,7 @@ def _ensure_roles(conn: sa.engine.Connection, roles_table: sa.Table) -> dict[str
     """Ensure all expected roles exist and return name→id mapping."""
     role_map: dict[str, uuid.UUID] = {}
     for name, description in ROLE_DESCRIPTIONS.items():
-        row = conn.execute(
-            sa.select(roles_table.c.id).where(roles_table.c.name == name)
-        ).fetchone()
+        row = conn.execute(sa.select(roles_table.c.id).where(roles_table.c.name == name)).fetchone()
         if row:
             role_map[name] = row[0]
         else:
@@ -212,9 +210,7 @@ def load_user(
     subscriptions_t = metadata.tables["subscriptions"]
 
     # Idempotency: check if user with this email already exists
-    existing = conn.execute(
-        sa.select(users_t.c.id).where(users_t.c.email == user.email)
-    ).fetchone()
+    existing = conn.execute(sa.select(users_t.c.id).where(users_t.c.email == user.email)).fetchone()
     if existing:
         log.debug("Skipping existing user: %s", user.email)
         return "skipped"
@@ -419,9 +415,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--database-url", required=True, help="PostgreSQL connection URL")
     parser.add_argument("--dry-run", action="store_true", help="Preview without writing")
     parser.add_argument("--verbose", action="store_true", help="Enable DEBUG logging")
-    parser.add_argument(
-        "--batch-size", type=int, default=50, help="Report progress every N users"
-    )
+    parser.add_argument("--batch-size", type=int, default=50, help="Report progress every N users")
     return parser.parse_args(argv)
 
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pre-commit hook replicating CI checks from .github/workflows/ci.yml
+# CI checks: ruff check, ruff format --check, pytest
+# Bonus: mypy (configured in pyproject.toml but not yet in CI)
+#
+# Install: ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+
+set -euo pipefail
+
+# Resolve repo root (works in worktrees too)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FAILED=0
+
+echo "=== pre-commit: Running CI checks ==="
+
+# 1. Ruff lint
+echo ""
+echo "--- ruff check ---"
+if ! ruff check .; then
+    echo "FAIL: ruff check found lint errors"
+    FAILED=1
+fi
+
+# 2. Ruff format
+echo ""
+echo "--- ruff format --check ---"
+if ! ruff format --check .; then
+    echo "FAIL: ruff format found formatting issues (run: ruff format .)"
+    FAILED=1
+fi
+
+# 3. Mypy type check (configured in pyproject.toml)
+echo ""
+echo "--- mypy ---"
+if command -v mypy &>/dev/null; then
+    if ! mypy src/; then
+        echo "FAIL: mypy found type errors"
+        FAILED=1
+    fi
+else
+    echo "SKIP: mypy not installed"
+fi
+
+# 4. Pytest (optional — can be slow, skip with PRE_COMMIT_SKIP_TESTS=1)
+echo ""
+if [ "${PRE_COMMIT_SKIP_TESTS:-0}" = "1" ]; then
+    echo "--- pytest (SKIPPED via PRE_COMMIT_SKIP_TESTS=1) ---"
+else
+    echo "--- pytest ---"
+    if command -v pytest &>/dev/null; then
+        if ! ENVIRONMENT=test pytest --tb=short -q; then
+            echo "FAIL: pytest found test failures"
+            FAILED=1
+        fi
+    else
+        echo "SKIP: pytest not installed (run: uv sync --extra dev)"
+    fi
+fi
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "=== pre-commit: FAILED — fix errors before committing ==="
+    exit 1
+fi
+
+echo "=== pre-commit: All checks passed ==="
+exit 0

--- a/src/app/models/subscription.py
+++ b/src/app/models/subscription.py
@@ -51,9 +51,7 @@ class Subscription(Base):
     )
     starts_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )

--- a/src/app/routers/subscriptions.py
+++ b/src/app/routers/subscriptions.py
@@ -99,13 +99,9 @@ async def get_user_subscription(
     return SubscriptionRead.model_validate(sub)
 
 
-def _verify_webhook_signature(
-    body: bytes, signature: str, secret: str
-) -> bool:
+def _verify_webhook_signature(body: bytes, signature: str, secret: str) -> bool:
     """Verify HMAC-SHA256 webhook signature."""
-    expected = hmac.new(
-        secret.encode(), body, hashlib.sha256
-    ).hexdigest()
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return hmac.compare_digest(f"sha256={expected}", signature)
 
 

--- a/src/app/schemas/auth.py
+++ b/src/app/schemas/auth.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-
 # --- JWT Token Schemas ---
 
 

--- a/src/app/services/oauth.py
+++ b/src/app/services/oauth.py
@@ -201,7 +201,7 @@ class AppleOAuthProvider(BaseOAuthProvider):
         """Generate a short-lived JWT client secret for Apple."""
         import time
 
-        from jose import jwt as jose_jwt  # type: ignore[import-untyped]
+        from jose import jwt as jose_jwt
 
         now = int(time.time())
         payload = {
@@ -211,7 +211,7 @@ class AppleOAuthProvider(BaseOAuthProvider):
             "aud": "https://appleid.apple.com",
             "sub": self.client_id,
         }
-        return jose_jwt.encode(  # type: ignore[no-any-return]
+        return jose_jwt.encode(
             payload,
             self.private_key,
             algorithm="ES256",

--- a/src/app/services/session.py
+++ b/src/app/services/session.py
@@ -96,9 +96,7 @@ async def list_user_sessions(
         redis_key = f"{REDIS_SESSION_PREFIX}{s.id}"
         last_active_raw: bytes | None = await redis.hget(redis_key, "last_active")  # type: ignore[misc]
         last_active: datetime = (
-            datetime.fromisoformat(last_active_raw.decode())
-            if last_active_raw
-            else s.last_active
+            datetime.fromisoformat(last_active_raw.decode()) if last_active_raw else s.last_active
         )
         enriched.append(
             {

--- a/src/app/services/subscription.py
+++ b/src/app/services/subscription.py
@@ -13,9 +13,7 @@ from src.app.models.subscription import Subscription, SubscriptionPlan, Subscrip
 TRIAL_DURATION_DAYS = 14
 
 
-async def get_current_subscription(
-    db: AsyncSession, user_id: uuid.UUID
-) -> Subscription | None:
+async def get_current_subscription(db: AsyncSession, user_id: uuid.UUID) -> Subscription | None:
     """Return the most recent subscription for a user."""
     result = await db.execute(
         select(Subscription)
@@ -44,9 +42,7 @@ async def get_subscription_status(db: AsyncSession, user_id: uuid.UUID) -> str:
     return sub.status.value
 
 
-async def expire_lapsed_subscriptions(
-    db: AsyncSession, user_id: uuid.UUID
-) -> None:
+async def expire_lapsed_subscriptions(db: AsyncSession, user_id: uuid.UUID) -> None:
     """Mark active subscriptions past their expires_at as expired.
 
     Call this from a background task or cron, not from read paths.
@@ -102,9 +98,7 @@ async def start_trial(db: AsyncSession, user_id: uuid.UUID) -> Subscription:
     return subscription
 
 
-async def cancel_subscription(
-    db: AsyncSession, user_id: uuid.UUID
-) -> Subscription | None:
+async def cancel_subscription(db: AsyncSession, user_id: uuid.UUID) -> Subscription | None:
     """Cancel the current active subscription. Sets expires_at to now."""
     sub = await get_current_subscription(db, user_id)
     if sub is None or sub.status != SubscriptionStatus.active:

--- a/src/app/services/user.py
+++ b/src/app/services/user.py
@@ -15,7 +15,6 @@ from src.app.models.role import UserRole
 from src.app.models.user import User
 from src.app.schemas.user import UserUpdate
 
-
 # --- User CRUD ---
 
 

--- a/src/app/services/verification.py
+++ b/src/app/services/verification.py
@@ -118,9 +118,7 @@ async def confirm_verification_token(
     verification.used_at = now
 
     # Mark user email as verified
-    user_result = await db.execute(
-        select(User).where(User.id == verification.user_id)
-    )
+    user_result = await db.execute(select(User).where(User.id == verification.user_id))
     user = user_result.scalar_one_or_none()
     if user is None:
         return None

--- a/tests/test_migrate_users.py
+++ b/tests/test_migrate_users.py
@@ -207,11 +207,16 @@ class TestParseNeo4jDatetime:
 # ---------------------------------------------------------------------------
 class TestParseArgs:
     def test_required_args(self) -> None:
-        args = parse_args([
-            "--neo4j-uri", "bolt://localhost:7687",
-            "--neo4j-password", "secret",
-            "--database-url", "postgresql://localhost/db",
-        ])
+        args = parse_args(
+            [
+                "--neo4j-uri",
+                "bolt://localhost:7687",
+                "--neo4j-password",
+                "secret",
+                "--database-url",
+                "postgresql://localhost/db",
+            ]
+        )
         assert args.neo4j_uri == "bolt://localhost:7687"
         assert args.neo4j_user == "neo4j"  # default
         assert args.neo4j_password == "secret"
@@ -220,30 +225,46 @@ class TestParseArgs:
         assert args.verbose is False
 
     def test_dry_run_flag(self) -> None:
-        args = parse_args([
-            "--neo4j-uri", "bolt://localhost:7687",
-            "--neo4j-password", "secret",
-            "--database-url", "postgresql://localhost/db",
-            "--dry-run",
-        ])
+        args = parse_args(
+            [
+                "--neo4j-uri",
+                "bolt://localhost:7687",
+                "--neo4j-password",
+                "secret",
+                "--database-url",
+                "postgresql://localhost/db",
+                "--dry-run",
+            ]
+        )
         assert args.dry_run is True
 
     def test_verbose_flag(self) -> None:
-        args = parse_args([
-            "--neo4j-uri", "bolt://localhost:7687",
-            "--neo4j-password", "secret",
-            "--database-url", "postgresql://localhost/db",
-            "--verbose",
-        ])
+        args = parse_args(
+            [
+                "--neo4j-uri",
+                "bolt://localhost:7687",
+                "--neo4j-password",
+                "secret",
+                "--database-url",
+                "postgresql://localhost/db",
+                "--verbose",
+            ]
+        )
         assert args.verbose is True
 
     def test_custom_batch_size(self) -> None:
-        args = parse_args([
-            "--neo4j-uri", "bolt://localhost:7687",
-            "--neo4j-password", "secret",
-            "--database-url", "postgresql://localhost/db",
-            "--batch-size", "100",
-        ])
+        args = parse_args(
+            [
+                "--neo4j-uri",
+                "bolt://localhost:7687",
+                "--neo4j-password",
+                "secret",
+                "--database-url",
+                "postgresql://localhost/db",
+                "--batch-size",
+                "100",
+            ]
+        )
         assert args.batch_size == 100
 
 

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -204,9 +204,7 @@ class TestCreateSession:
         # Check oldest session is revoked
         from sqlalchemy import select
 
-        result = await db_session.execute(
-            select(Session).where(Session.id == session_ids[0])
-        )
+        result = await db_session.execute(select(Session).where(Session.id == session_ids[0]))
         oldest = result.scalar_one()
         assert oldest.revoked_at is not None
 
@@ -225,7 +223,9 @@ class TestListSessions:
             )
 
         sessions = await list_user_sessions(
-            db=db_session, redis=fake_redis, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert len(sessions) == 2
 
@@ -249,11 +249,16 @@ class TestListSessions:
         )
 
         await revoke_session(
-            db=db_session, redis=fake_redis, session_id=s1.id, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            session_id=s1.id,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
 
         sessions = await list_user_sessions(
-            db=db_session, redis=fake_redis, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert len(sessions) == 1
 
@@ -291,7 +296,10 @@ class TestRevokeSession:
         )
 
         revoked = await revoke_session(
-            db=db_session, redis=fake_redis, session_id=s.id, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            session_id=s.id,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert revoked is True
 
@@ -352,12 +360,16 @@ class TestRevokeAllSessions:
             )
 
         count = await revoke_all_sessions(
-            db=db_session, redis=fake_redis, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert count == 3
 
         sessions = await list_user_sessions(
-            db=db_session, redis=fake_redis, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert len(sessions) == 0
 
@@ -384,7 +396,9 @@ class TestRevokeAllSessions:
         assert count == 2
 
         sessions = await list_user_sessions(
-            db=db_session, redis=fake_redis, user_id=test_user.id  # type: ignore[arg-type]
+            db=db_session,
+            redis=fake_redis,
+            user_id=test_user.id,  # type: ignore[arg-type]
         )
         assert len(sessions) == 1
         assert sessions[0]["id"] == session_ids[2]
@@ -399,7 +413,8 @@ class TestSessionActivity:
         await fake_redis.hset(redis_key, "last_active", "2026-01-01T00:00:00+00:00")
 
         await update_session_activity(
-            redis=fake_redis, session_id=session_id  # type: ignore[arg-type]
+            redis=fake_redis,
+            session_id=session_id,  # type: ignore[arg-type]
         )
 
         raw = await fake_redis.hget(redis_key, "last_active")
@@ -413,10 +428,12 @@ class TestSessionActivity:
         await fake_redis.hset(redis_key, "user_id", "fake")
 
         assert await is_session_active(
-            redis=fake_redis, session_id=session_id  # type: ignore[arg-type]
+            redis=fake_redis,
+            session_id=session_id,  # type: ignore[arg-type]
         )
 
     async def test_is_session_active_false(self, fake_redis: FakeRedis) -> None:
         assert not await is_session_active(
-            redis=fake_redis, session_id=uuid.uuid4()  # type: ignore[arg-type]
+            redis=fake_redis,
+            session_id=uuid.uuid4(),  # type: ignore[arg-type]
         )

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -170,9 +170,7 @@ def _auth_header(user: User) -> dict[str, str]:
 
 
 def _webhook_signature(body: bytes) -> str:
-    sig = hmac_mod.new(
-        WEBHOOK_SECRET.encode(), body, hashlib.sha256
-    ).hexdigest()
+    sig = hmac_mod.new(WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
     return f"sha256={sig}"
 
 
@@ -373,9 +371,7 @@ class TestGetUserSubscription:
         assert resp.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_no_subscription_returns_404(
-        self, client: AsyncClient, admin_user: User
-    ) -> None:
+    async def test_no_subscription_returns_404(self, client: AsyncClient, admin_user: User) -> None:
         resp = await client.get(
             f"/api/v1/subscriptions/{uuid.uuid4()}",
             headers=_auth_header(admin_user),
@@ -385,14 +381,14 @@ class TestGetUserSubscription:
 
 class TestWebhook:
     @pytest.mark.asyncio
-    async def test_subscription_created(
-        self, client: AsyncClient, regular_user: User
-    ) -> None:
-        payload = json.dumps({
-            "event_type": "subscription.created",
-            "user_id": str(regular_user.id),
-            "plan": "researcher",
-        }).encode()
+    async def test_subscription_created(self, client: AsyncClient, regular_user: User) -> None:
+        payload = json.dumps(
+            {
+                "event_type": "subscription.created",
+                "user_id": str(regular_user.id),
+                "plan": "researcher",
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,
@@ -405,13 +401,13 @@ class TestWebhook:
         assert resp.json()["status"] == "processed"
 
     @pytest.mark.asyncio
-    async def test_unknown_event_ignored(
-        self, client: AsyncClient, regular_user: User
-    ) -> None:
-        payload = json.dumps({
-            "event_type": "invoice.paid",
-            "user_id": str(regular_user.id),
-        }).encode()
+    async def test_unknown_event_ignored(self, client: AsyncClient, regular_user: User) -> None:
+        payload = json.dumps(
+            {
+                "event_type": "invoice.paid",
+                "user_id": str(regular_user.id),
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,
@@ -427,11 +423,13 @@ class TestWebhook:
     async def test_invalid_signature_rejected(
         self, client: AsyncClient, regular_user: User
     ) -> None:
-        payload = json.dumps({
-            "event_type": "subscription.created",
-            "user_id": str(regular_user.id),
-            "plan": "researcher",
-        }).encode()
+        payload = json.dumps(
+            {
+                "event_type": "subscription.created",
+                "user_id": str(regular_user.id),
+                "plan": "researcher",
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,
@@ -460,14 +458,14 @@ class TestWebhook:
     async def test_subscription_cancelled(
         self, client: AsyncClient, regular_user: User, db_session: AsyncSession
     ) -> None:
-        await sub_svc.create_subscription(
-            db_session, regular_user.id, "researcher"
-        )
+        await sub_svc.create_subscription(db_session, regular_user.id, "researcher")
         await db_session.commit()
-        payload = json.dumps({
-            "event_type": "subscription.cancelled",
-            "user_id": str(regular_user.id),
-        }).encode()
+        payload = json.dumps(
+            {
+                "event_type": "subscription.cancelled",
+                "user_id": str(regular_user.id),
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,
@@ -483,16 +481,16 @@ class TestWebhook:
     async def test_subscription_updated(
         self, client: AsyncClient, regular_user: User, db_session: AsyncSession
     ) -> None:
-        await sub_svc.create_subscription(
-            db_session, regular_user.id, "researcher"
-        )
+        await sub_svc.create_subscription(db_session, regular_user.id, "researcher")
         await db_session.commit()
-        payload = json.dumps({
-            "event_type": "subscription.updated",
-            "user_id": str(regular_user.id),
-            "status": "suspended",
-            "plan": "institutional",
-        }).encode()
+        payload = json.dumps(
+            {
+                "event_type": "subscription.updated",
+                "user_id": str(regular_user.id),
+                "status": "suspended",
+                "plan": "institutional",
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,
@@ -508,11 +506,13 @@ class TestWebhook:
     async def test_webhook_invalid_status_rejected(
         self, client: AsyncClient, regular_user: User
     ) -> None:
-        payload = json.dumps({
-            "event_type": "subscription.updated",
-            "user_id": str(regular_user.id),
-            "status": "bogus_status",
-        }).encode()
+        payload = json.dumps(
+            {
+                "event_type": "subscription.updated",
+                "user_id": str(regular_user.id),
+                "status": "bogus_status",
+            }
+        ).encode()
         resp = await client.post(
             "/api/v1/subscriptions/webhook",
             content=payload,

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -280,9 +280,7 @@ class TestTokenHashing:
 
 
 class TestSendEndpoint:
-    async def test_send_success(
-        self, client: AsyncClient, test_user: User
-    ) -> None:
+    async def test_send_success(self, client: AsyncClient, test_user: User) -> None:
         with patch(
             "src.app.routers.verification.send_verification_email",
             new_callable=AsyncMock,
@@ -296,9 +294,7 @@ class TestSendEndpoint:
             assert resp.json()["message"] == "Verification email sent"
             mock_send.assert_awaited_once()
 
-    async def test_send_already_verified(
-        self, client: AsyncClient, verified_user: User
-    ) -> None:
+    async def test_send_already_verified(self, client: AsyncClient, verified_user: User) -> None:
         resp = await client.post(
             "/api/v1/verification/send",
             json={"email": verified_user.email},
@@ -307,9 +303,7 @@ class TestSendEndpoint:
         assert resp.status_code == 400
         assert "already verified" in resp.json()["detail"]
 
-    async def test_send_email_mismatch(
-        self, client: AsyncClient, test_user: User
-    ) -> None:
+    async def test_send_email_mismatch(self, client: AsyncClient, test_user: User) -> None:
         resp = await client.post(
             "/api/v1/verification/send",
             json={"email": "other@example.com"},
@@ -318,9 +312,7 @@ class TestSendEndpoint:
         assert resp.status_code == 400
         assert "does not match" in resp.json()["detail"]
 
-    async def test_send_rate_limited(
-        self, client: AsyncClient, test_user: User
-    ) -> None:
+    async def test_send_rate_limited(self, client: AsyncClient, test_user: User) -> None:
         for _ in range(3):
             with patch(
                 "src.app.routers.verification.send_verification_email",
@@ -352,9 +344,7 @@ class TestConfirmEndpoint:
 
 
 class TestStatusEndpoint:
-    async def test_status_not_verified(
-        self, client: AsyncClient, test_user: User
-    ) -> None:
+    async def test_status_not_verified(self, client: AsyncClient, test_user: User) -> None:
         resp = await client.get(
             "/api/v1/verification/status",
             headers=_auth_header(test_user),
@@ -364,9 +354,7 @@ class TestStatusEndpoint:
         assert data["email"] == test_user.email
         assert data["email_verified"] is False
 
-    async def test_status_verified(
-        self, client: AsyncClient, verified_user: User
-    ) -> None:
+    async def test_status_verified(self, client: AsyncClient, verified_user: User) -> None:
         resp = await client.get(
             "/api/v1/verification/status",
             headers=_auth_header(verified_user),


### PR DESCRIPTION
## Summary
- Fix 6 ruff I001 import sorting violations in hooks, alembic, schemas, and services
- Remove stale type-ignore comments in oauth.py (types-python-jose stubs now cover these calls)
- Fix E501 line-too-long in validate_commit_identity.py, add noqa for intentional side-effect import in alembic/env.py
- Run ruff format on all 12 non-compliant files repo-wide
- Add scripts/pre-commit.sh replicating CI checks locally

## CI Status
Ruff lint and format checks pass. The runner step fails due to a pre-existing missing neo4j module in migrate_users. This also fails on main and is not caused by this PR.

## Related Issues
Closes #45, Closes #46, Closes #47

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved