### PR TITLE
ops: add ruff-format + ruff --fix pre-commit hooks

### DIFF
--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -2,5 +2,10 @@
   "Nadia Boukhari": "parametrization+Nadia.Boukhari@gmail.com",
   "Anya Kowalczyk": "parametrization+Anya.Kowalczyk@gmail.com",
   "Mateo Salazar": "parametrization+Mateo.Salazar@gmail.com",
-  "Idris Yusuf": "parametrization+Idris.Yusuf@gmail.com"
+  "Idris Yusuf": "parametrization+Idris.Yusuf@gmail.com",
+
+  "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+  "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+  "Santiago Ferreira": "parametrization+Santiago.Ferreira@gmail.com",
+  "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# Pre-commit hooks for noorinalabs-user-service
+# Install: uvx pre-commit install
+# Docs: https://pre-commit.com/
+#
+# ruff-format runs first so format fixes don't trigger re-lint.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.6
+    hooks:
+      - id: ruff-format
+        name: ruff-format
+      - id: ruff
+        args: [--fix]
+        name: ruff-lint


### PR DESCRIPTION
## Summary

Implements [`noorinalabs/noorinalabs-main#110`](https://github.com/noorinalabs/noorinalabs-main/issues/110) for `noorinalabs-user-service`: adds the standard ruff pre-commit config so lint and format errors autofix at commit time instead of failing CI.

## Changes

**`.pre-commit-config.yaml`** (new) — single ruff hook block:
- `ruff-format` runs first so format fixes don't trigger re-lint
- `ruff` with `--fix` autofixes safe lint violations
- Pinned to `v0.11.6` to match the org-wide pin used in `noorinalabs-isnad-graph`

`pre-commit run ruff-format --all-files` and `pre-commit run ruff --all-files` both pass clean against current `main`, so no backlog to clear here — the hook adds no friction on existing files.

## Prerequisite commit

The branch starts with `infra: Add org-level coordinators to roster` (Aino Virtanen, sha `9574431`), which adds Nadia Khoury, Wanjiku, Santiago, and Aino to `.claude/team/roster.json` so org-level coordinators can land repo-spanning ops PRs. Steven approved this expansion. A separate W9 tech-debt issue will track making the cross-repo roster detection automatic so we don't have to sync names by hand.

## Test plan

- [x] `uvx pre-commit run ruff-format --all-files` → Passed
- [x] `uvx pre-commit run ruff --all-files` → Passed
- [ ] CI green
- [ ] Reviewer to confirm hook ordering matches spec (ruff-format before ruff)

## Issue

Refs noorinalabs/noorinalabs-main#110

🤖 Generated with [Claude Code](https://claude.com/claude-code)