### PR TITLE
fix(ci): unblock main — add neo4j dev dep, scan published image digest

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -61,6 +61,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
@@ -74,7 +75,12 @@ jobs:
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          # Scan by digest — guaranteed to exist immediately after `Build and push`
+          # and not subject to tag-resolution races. Previously used
+          # `:${{ github.ref_name }}` which on a `main` push resolves to `:main`,
+          # but the metadata-action emits only `:latest` and `:sha-XXXX` for
+          # main pushes — so the scan always 404'd with MANIFEST_UNKNOWN.
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: "1"
           severity: CRITICAL,HIGH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "types-python-jose>=3.3.0",
     "types-pyasn1>=0.6.0",
     "aiosqlite>=0.20.0",
+    "neo4j>=6.1.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -676,6 +676,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
+]
+
+[[package]]
 name = "noorinalabs-user-service"
 version = "0.1.0"
 source = { editable = "." }
@@ -703,6 +715,7 @@ dev = [
     { name = "aiosqlite" },
     { name = "httpx" },
     { name = "mypy" },
+    { name = "neo4j" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -722,6 +735,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
+    { name = "neo4j", marker = "extra == 'dev'", specifier = ">=6.1.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
@@ -985,6 +999,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two CI failures on `noorinalabs-user-service` `main` — bundled per #111 since both are CI scope and red on the same SHAs.

| Workflow | Was failing because | Fix |
|---|---|---|
| `CI / check` | `tests/test_migrate_users.py` imports `scripts.migrate_users` → `from neo4j import ...` and neo4j wasn't a dep | `uv add --optional dev neo4j` |
| `Publish to GHCR / build-and-push` | Trivy scanned `:${{ github.ref_name }}`; on a `main` push that resolves to `:main`, but the workflow only pushes `:latest` and `:sha-XXXX` | Scan by digest (`@${{ steps.build.outputs.digest }}`) instead of by tag — race-free |

No `# noqa`, `xfail`, `--no-verify`, or test deletion.

## Verification (local)

- `uv sync --extra dev` — installs neo4j into the dev env
- `uv run python -m pytest -q` — **185 passed**, 1 unrelated DeprecationWarning (HTTP_422 from FastAPI)
- `uv run python -c "from scripts.migrate_users import *"` — imports cleanly

The Trivy fix can only be validated by CI on this PR (needs the actual GHCR push to produce a digest). Confirmed the `digest` output exists on `docker/build-push-action` v6 — added `id: build` to wire it through.

## TechDebt

None new.

Closes noorinalabs/noorinalabs-user-service#59
Refs noorinalabs/noorinalabs-main#111

## Test plan

- [x] Local `uv sync --extra dev && pytest -q` green
- [ ] CI: `CI / check` green on this PR
- [ ] CI: `Publish to GHCR` green on this PR (tests both the digest scan path and Trivy clearance on the actual published image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
