### PR TITLE
fix(auth): GET OAuth callback handler for server-side flow (#66)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,14 @@ AUTH_FACEBOOK_APP_SECRET=
 
 # OAuth — Redirect base URL (used to build callback URLs)
 AUTH_OAUTH_REDIRECT_BASE_URL=http://localhost:8000
+
+# OAuth — Server-side flow (GET callback)
+# Frontend destination after successful OAuth. Receives ?token=...&is_new_user=...
+# on success, or ?error=<code> on failure. May be absolute or relative to the
+# request origin.
+AUTH_OAUTH_POST_LOGIN_URL=/auth/callback
+# TTL for state/code_verifier entries in Redis (seconds — upper bound on OAuth round-trip)
+AUTH_OAUTH_STATE_TTL_SECONDS=600
+# Secure flag on the refresh_token cookie. Must be true in production (HTTPS);
+# set to false in local HTTP development.
+AUTH_OAUTH_REFRESH_COOKIE_SECURE=true

--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,15 @@ AUTH_FACEBOOK_APP_SECRET=
 AUTH_OAUTH_REDIRECT_BASE_URL=http://localhost:8000
 
 # OAuth — Server-side flow (GET callback)
-# Frontend destination after successful OAuth. Receives ?token=...&is_new_user=...
-# on success, or ?error=<code> on failure. May be absolute or relative to the
-# request origin.
+# BASE path for the frontend destination after successful OAuth. The handler
+# always appends `/{provider}` to match the frontend route
+# `auth/callback/:provider` (required path param — see isnad-graph
+# frontend/src/App.tsx). The final URL shape is:
+#   {AUTH_OAUTH_POST_LOGIN_URL}/{provider}?token=...&is_new_user=0|1&needs_verification=0
+# or on failure:
+#   {AUTH_OAUTH_POST_LOGIN_URL}/{provider}?error=<code>
+# May be absolute or relative to the request origin. Do NOT include `/{provider}`
+# in the value — the handler appends it.
 AUTH_OAUTH_POST_LOGIN_URL=/auth/callback
 # TTL for state/code_verifier entries in Redis (seconds — upper bound on OAuth round-trip)
 AUTH_OAUTH_STATE_TTL_SECONDS=600

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -74,8 +74,13 @@ class Settings(BaseSettings):
     AUTH_OAUTH_REDIRECT_BASE_URL: str = "http://localhost:8000"
 
     # OAuth — Server-side flow (GET callback)
-    # Frontend destination after successful OAuth. Receives ?token=...&is_new_user=...
-    # on success, or ?error=<code> on failure. May be absolute or same-origin relative.
+    # BASE path for the frontend destination after successful OAuth. The handler
+    # always appends `/{provider}` to match the frontend route
+    # `auth/callback/:provider` (required path param). Final shape:
+    #   {AUTH_OAUTH_POST_LOGIN_URL}/{provider}?token=...&is_new_user=0|1
+    # or on failure:
+    #   {AUTH_OAUTH_POST_LOGIN_URL}/{provider}?error=<code>
+    # May be absolute or same-origin relative. Do NOT include `/{provider}` — appended.
     AUTH_OAUTH_POST_LOGIN_URL: str = "/auth/callback"
     # TTL for state/code_verifier entries in Redis (upper bound on OAuth round-trip)
     AUTH_OAUTH_STATE_TTL_SECONDS: int = 600

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -73,6 +73,16 @@ class Settings(BaseSettings):
     # OAuth — Redirect base URL
     AUTH_OAUTH_REDIRECT_BASE_URL: str = "http://localhost:8000"
 
+    # OAuth — Server-side flow (GET callback)
+    # Frontend destination after successful OAuth. Receives ?token=...&is_new_user=...
+    # on success, or ?error=<code> on failure. May be absolute or same-origin relative.
+    AUTH_OAUTH_POST_LOGIN_URL: str = "/auth/callback"
+    # TTL for state/code_verifier entries in Redis (upper bound on OAuth round-trip)
+    AUTH_OAUTH_STATE_TTL_SECONDS: int = 600
+    # Whether to set the refresh-token cookie with Secure=True. Must be True in prod;
+    # set to False in local HTTP dev.
+    AUTH_OAUTH_REFRESH_COOKIE_SECURE: bool = True
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/src/app/routers/auth.py
+++ b/src/app/routers/auth.py
@@ -1,14 +1,27 @@
-"""Auth routes — JWT token endpoints and OAuth login/callback."""
+"""Auth routes — JWT token endpoints and OAuth login/callback.
+
+OAuth flow (server-side, post #66):
+  1. Frontend hits GET /auth/oauth/{provider}/login — backend stashes state +
+     code_verifier in Redis (keyed by state) and returns the authorization_url.
+  2. Frontend redirects the browser to authorization_url.
+  3. Provider redirects the browser to GET /auth/oauth/{provider}/callback?code=..&state=..
+  4. Backend validates state, exchanges code, upserts user, mints tokens, sets the
+     refresh_token as an httpOnly cookie, and redirects the browser to
+     AUTH_OAUTH_POST_LOGIN_URL with ?token=<access>&is_new_user=0|1 on success,
+     or ?error=<code> on failure.
+"""
 
 from __future__ import annotations
 
 import json
 import secrets
+import urllib.parse
 import uuid
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from fastapi.responses import RedirectResponse
 from jose.exceptions import JWTError
 from redis.asyncio import Redis
 from sqlalchemy import select, text
@@ -18,8 +31,6 @@ from src.app.config import Settings, get_settings
 from src.app.database import get_db_session, get_redis
 from src.app.models.user import User
 from src.app.schemas.auth import (
-    OAuthCallbackRequest,
-    OAuthCallbackResponse,
     OAuthLoginResponse,
     RefreshRequest,
     RevokeRequest,
@@ -47,6 +58,18 @@ RedisDep = Annotated[Redis, Depends(get_redis)]
 
 AUTH_CODE_PREFIX = "auth_code:"
 AUTH_CODE_TTL_SECONDS = 60
+
+# Redis key prefix for in-flight OAuth state (CSRF + PKCE verifier)
+OAUTH_STATE_PREFIX = "oauth_state:"
+
+# Error codes emitted in the post-login redirect URL. Kept in sync with
+# isnad-graph frontend AuthCallbackPage.tsx ERROR_MESSAGES.
+OAUTH_ERROR_INVALID_STATE = "invalid_state"
+OAUTH_ERROR_EXCHANGE_FAILED = "oauth_exchange_failed"
+OAUTH_ERROR_USER_INFO_FAILED = "oauth_exchange_failed"
+OAUTH_ERROR_EMAIL_MISMATCH = "email_mismatch"
+OAUTH_ERROR_PROVIDER_DENIED = "provider_denied"
+OAUTH_ERROR_UNSUPPORTED_PROVIDER = "unsupported_provider"
 
 VALID_PROVIDERS = {p.value for p in OAuthProvider}
 
@@ -209,15 +232,40 @@ async def validate_token(
 # --- OAuth Endpoints ---
 
 
+def _build_error_redirect(settings: Settings, error_code: str) -> RedirectResponse:
+    """Build a RedirectResponse to the frontend post-login URL with an error param."""
+    base = settings.AUTH_OAUTH_POST_LOGIN_URL or "/"
+    separator = "&" if "?" in base else "?"
+    url = f"{base}{separator}error={urllib.parse.quote(error_code)}"
+    return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+
+
 @router.get("/oauth/{provider}/login", response_model=OAuthLoginResponse)
-async def oauth_login(provider: str, settings: SettingsDep) -> OAuthLoginResponse:
-    """Generate an authorization URL with PKCE for the given provider."""
+async def oauth_login(
+    provider: str,
+    settings: SettingsDep,
+    redis: RedisDep,
+) -> OAuthLoginResponse:
+    """Generate an authorization URL with PKCE for the given provider.
+
+    The state and code_verifier are stored in Redis (keyed by state) for the
+    server-side callback handler to retrieve. Returning them to the client is
+    kept for backwards compatibility with earlier SPA integrations but is no
+    longer required for the GET callback flow.
+    """
     if provider not in VALID_PROVIDERS:
         raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
 
     state = secrets.token_urlsafe(32)
     code_verifier, code_challenge = generate_pkce_pair()
     redirect_uri = f"{settings.AUTH_OAUTH_REDIRECT_BASE_URL}/auth/oauth/{provider}/callback"
+
+    # Stash state + code_verifier + provider so the GET callback can verify and exchange.
+    await redis.setex(
+        f"{OAUTH_STATE_PREFIX}{state}",
+        settings.AUTH_OAUTH_STATE_TTL_SECONDS,
+        json.dumps({"provider": provider, "code_verifier": code_verifier}),
+    )
 
     oauth = get_oauth_provider(provider, settings)
     authorization_url = oauth.get_authorization_url(state, code_challenge, redirect_uri)
@@ -229,49 +277,81 @@ async def oauth_login(provider: str, settings: SettingsDep) -> OAuthLoginRespons
     )
 
 
-@router.post("/oauth/{provider}/callback", response_model=OAuthCallbackResponse)
-async def oauth_callback(
+@router.get("/oauth/{provider}/callback", response_class=RedirectResponse)
+async def oauth_callback_get(
     provider: str,
-    body: OAuthCallbackRequest,
+    request: Request,
     settings: SettingsDep,
-    db: AsyncSession = Depends(get_db_session),  # noqa: B008
-    redis: Redis = Depends(get_redis),  # noqa: B008
-) -> OAuthCallbackResponse:
-    """Handle the OAuth callback — exchange code, find/create user, return user data.
+    db: DbDep,
+    redis: RedisDep,
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    error: str | None = Query(default=None),
+) -> RedirectResponse:
+    """Server-side OAuth callback — handles the provider's GET redirect.
 
-    Issues a one-time authorization code that the client must exchange at /auth/token
-    to obtain JWT tokens. This ensures tokens can only be minted after a real OAuth flow.
+    This is the endpoint OAuth providers (Google, GitHub, Apple, Facebook) redirect
+    the user's browser to after consent. It:
+      1. Validates state (CSRF) against Redis, retrieves the stored code_verifier.
+      2. Exchanges the authorization code for provider tokens.
+      3. Resolves user info and finds-or-creates the local user.
+      4. Mints an access token + refresh token, sets the refresh token as an
+         httpOnly cookie, and redirects the browser to AUTH_OAUTH_POST_LOGIN_URL
+         with the access token on a query param (matching the frontend
+         AuthCallbackPage contract).
+
+    On any error, redirects to AUTH_OAUTH_POST_LOGIN_URL with ?error=<code>. We
+    use browser redirects for every exit path because this URL is hit by the
+    user's browser, not by JS — a JSON error response would be a dead end.
+
+    Issue: noorinalabs/noorinalabs-user-service#66.
     """
+    # Provider-denied consent (e.g. "access_denied") → bounce to frontend with error
+    if error:
+        return _build_error_redirect(settings, OAUTH_ERROR_PROVIDER_DENIED)
+
     if provider not in VALID_PROVIDERS:
-        raise HTTPException(status_code=400, detail=f"Unsupported provider: {provider}")
+        return _build_error_redirect(settings, OAUTH_ERROR_UNSUPPORTED_PROVIDER)
+
+    if not code or not state:
+        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+
+    # Validate state (CSRF) and fetch the PKCE code_verifier. getdel() ensures the
+    # state is consumed exactly once — replay of the same callback URL is blocked.
+    state_key = f"{OAUTH_STATE_PREFIX}{state}"
+    raw_state = await redis.getdel(state_key)
+    if raw_state is None:
+        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+
+    state_data: dict[str, str] = json.loads(raw_state)
+    # Defense in depth: the state entry is keyed by provider at create time; if the
+    # user tampered with the `{provider}` path segment, refuse.
+    if state_data.get("provider") != provider:
+        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+    code_verifier = state_data["code_verifier"]
 
     redirect_uri = f"{settings.AUTH_OAUTH_REDIRECT_BASE_URL}/auth/oauth/{provider}/callback"
     oauth = get_oauth_provider(provider, settings)
 
-    # Exchange authorization code for tokens
+    # Exchange code → provider tokens. Provider failures (network, 4xx, malformed
+    # response) must bounce the user back with a readable error, not leak as 500.
     try:
-        tokens = await oauth.exchange_code(body.code, body.code_verifier, redirect_uri)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=502,
-            detail="Failed to exchange authorization code with the provider",
-        ) from exc
+        tokens = await oauth.exchange_code(code, code_verifier, redirect_uri)
+    except Exception:
+        return _build_error_redirect(settings, OAUTH_ERROR_EXCHANGE_FAILED)
 
-    # For Apple, user info is in id_token; for others, use access_token
+    # Fetch user info. Apple returns identity in the id_token; others use access_token.
     if provider == "apple":
         token_for_user_info: str = tokens.get("id_token", "")
     else:
-        token_for_user_info = tokens["access_token"]
+        token_for_user_info = tokens.get("access_token", "")
 
     try:
         user_info = await oauth.get_user_info(token_for_user_info)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=502,
-            detail="Failed to retrieve user info from the provider",
-        ) from exc
+    except Exception:
+        return _build_error_redirect(settings, OAUTH_ERROR_USER_INFO_FAILED)
 
-    # Find or create user, link OAuth account
+    # Find-or-create user, link OAuth account
     try:
         result = await find_or_create_oauth_user(
             db,
@@ -281,10 +361,12 @@ async def oauth_callback(
             display_name=user_info.display_name,
             avatar_url=user_info.avatar_url,
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError:
+        # Missing email / email-mismatch-style errors bounce the user back with a
+        # readable error code the frontend can render.
+        return _build_error_redirect(settings, OAUTH_ERROR_EMAIL_MISMATCH)
 
-    # Fetch user roles and subscription for the authorization code payload
+    # Collect roles + subscription for the access-token claims
     roles_result = await db.execute(
         text(
             "SELECT r.name FROM roles r "
@@ -296,29 +378,52 @@ async def oauth_callback(
     roles = [row[0] for row in roles_result.fetchall()]
     subscription_status = await get_subscription_status(db, result.user.id)
 
-    # Issue a one-time authorization code stored in Redis
-    authorization_code = secrets.token_urlsafe(48)
-    auth_data = json.dumps(
-        {
-            "user_id": str(result.user.id),
-            "email": result.user.email,
-            "roles": roles,
-            "subscription_status": subscription_status,
-        }
-    )
-    await redis.setex(
-        f"{AUTH_CODE_PREFIX}{authorization_code}",
-        AUTH_CODE_TTL_SECONDS,
-        auth_data,
-    )
-
-    return OAuthCallbackResponse(
+    # Mint tokens directly (no intermediate one-time code — the browser round-trip
+    # via redirect is already the single-use handoff). The access token goes on the
+    # redirect URL (the frontend AuthCallbackPage stores it in localStorage); the
+    # refresh token goes in an httpOnly cookie so JS cannot read it.
+    access_token, _ = create_access_token(
+        settings=settings,
         user_id=result.user.id,
         email=result.user.email,
-        display_name=result.user.display_name,
-        avatar_url=result.user.avatar_url,
-        is_new_user=result.is_new_user,
-        provider=provider,
-        created_at=result.user.created_at,
-        authorization_code=authorization_code,
+        roles=roles,
+        subscription_status=subscription_status,
     )
+    refresh_token = create_refresh_token()
+    await store_refresh_token(
+        db=db,
+        user_id=result.user.id,
+        refresh_token=refresh_token,
+        expires_days=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS,
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    # Build the success redirect with the access token and new-user flag.
+    post_login_base = settings.AUTH_OAUTH_POST_LOGIN_URL or "/"
+    separator = "&" if "?" in post_login_base else "?"
+    params = urllib.parse.urlencode(
+        {
+            "token": access_token,
+            "is_new_user": "1" if result.is_new_user else "0",
+            # OAuth users are created with email_verified=True, so verification is
+            # never needed via this flow — but we emit the flag for frontend parity.
+            "needs_verification": "0",
+        }
+    )
+    redirect_url = f"{post_login_base}{separator}{params}"
+    response = RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
+
+    # Refresh-token cookie: httpOnly + SameSite=Lax (Lax is required so the cookie
+    # survives the cross-site redirect from the OAuth provider back to us; Strict
+    # would drop it on the first hop). Secure flag is env-gated for local HTTP dev.
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        max_age=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,
+        httponly=True,
+        secure=settings.AUTH_OAUTH_REFRESH_COOKIE_SECURE,
+        samesite="lax",
+        path="/auth",
+    )
+    return response

--- a/src/app/routers/auth.py
+++ b/src/app/routers/auth.py
@@ -232,11 +232,33 @@ async def validate_token(
 # --- OAuth Endpoints ---
 
 
-def _build_error_redirect(settings: Settings, error_code: str) -> RedirectResponse:
+def _build_post_login_url(settings: Settings, provider: str, params: dict[str, str]) -> str:
+    """Build the post-login redirect URL.
+
+    `AUTH_OAUTH_POST_LOGIN_URL` is the BASE path (e.g. `/auth/callback`); the
+    `/{provider}` segment is always appended here so the URL matches the
+    frontend's React Router route `auth/callback/:provider` (required param).
+    Per review on #66 / fix for isnad-graph#824 — picked option (a) from Anya's
+    review: setting is base, provider is always appended by the handler. This
+    avoids template-substitution footguns ({provider} stray braces, missing
+    placeholders, etc.) and keeps the setting a plain path string.
+
+    `provider` comes from the FastAPI path parameter, which is validated
+    against `VALID_PROVIDERS` in every caller — never user-supplied arbitrary
+    text at this point.
+    """
+    base = (settings.AUTH_OAUTH_POST_LOGIN_URL or "/").rstrip("/")
+    # URL-encode the provider even though we only ever pass validated values —
+    # belt-and-braces in case VALID_PROVIDERS ever includes a special character.
+    path = f"{base}/{urllib.parse.quote(provider, safe='')}"
+    if not params:
+        return path
+    return f"{path}?{urllib.parse.urlencode(params)}"
+
+
+def _build_error_redirect(settings: Settings, provider: str, error_code: str) -> RedirectResponse:
     """Build a RedirectResponse to the frontend post-login URL with an error param."""
-    base = settings.AUTH_OAUTH_POST_LOGIN_URL or "/"
-    separator = "&" if "?" in base else "?"
-    url = f"{base}{separator}error={urllib.parse.quote(error_code)}"
+    url = _build_post_login_url(settings, provider, {"error": error_code})
     return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
 
 
@@ -308,26 +330,26 @@ async def oauth_callback_get(
     """
     # Provider-denied consent (e.g. "access_denied") → bounce to frontend with error
     if error:
-        return _build_error_redirect(settings, OAUTH_ERROR_PROVIDER_DENIED)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_PROVIDER_DENIED)
 
     if provider not in VALID_PROVIDERS:
-        return _build_error_redirect(settings, OAUTH_ERROR_UNSUPPORTED_PROVIDER)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_UNSUPPORTED_PROVIDER)
 
     if not code or not state:
-        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_INVALID_STATE)
 
     # Validate state (CSRF) and fetch the PKCE code_verifier. getdel() ensures the
     # state is consumed exactly once — replay of the same callback URL is blocked.
     state_key = f"{OAUTH_STATE_PREFIX}{state}"
     raw_state = await redis.getdel(state_key)
     if raw_state is None:
-        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_INVALID_STATE)
 
     state_data: dict[str, str] = json.loads(raw_state)
     # Defense in depth: the state entry is keyed by provider at create time; if the
     # user tampered with the `{provider}` path segment, refuse.
     if state_data.get("provider") != provider:
-        return _build_error_redirect(settings, OAUTH_ERROR_INVALID_STATE)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_INVALID_STATE)
     code_verifier = state_data["code_verifier"]
 
     redirect_uri = f"{settings.AUTH_OAUTH_REDIRECT_BASE_URL}/auth/oauth/{provider}/callback"
@@ -338,7 +360,7 @@ async def oauth_callback_get(
     try:
         tokens = await oauth.exchange_code(code, code_verifier, redirect_uri)
     except Exception:
-        return _build_error_redirect(settings, OAUTH_ERROR_EXCHANGE_FAILED)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_EXCHANGE_FAILED)
 
     # Fetch user info. Apple returns identity in the id_token; others use access_token.
     if provider == "apple":
@@ -349,7 +371,7 @@ async def oauth_callback_get(
     try:
         user_info = await oauth.get_user_info(token_for_user_info)
     except Exception:
-        return _build_error_redirect(settings, OAUTH_ERROR_USER_INFO_FAILED)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_USER_INFO_FAILED)
 
     # Find-or-create user, link OAuth account
     try:
@@ -364,7 +386,7 @@ async def oauth_callback_get(
     except ValueError:
         # Missing email / email-mismatch-style errors bounce the user back with a
         # readable error code the frontend can render.
-        return _build_error_redirect(settings, OAUTH_ERROR_EMAIL_MISMATCH)
+        return _build_error_redirect(settings, provider, OAUTH_ERROR_EMAIL_MISMATCH)
 
     # Collect roles + subscription for the access-token claims
     roles_result = await db.execute(
@@ -399,19 +421,21 @@ async def oauth_callback_get(
         user_agent=request.headers.get("user-agent"),
     )
 
-    # Build the success redirect with the access token and new-user flag.
-    post_login_base = settings.AUTH_OAUTH_POST_LOGIN_URL or "/"
-    separator = "&" if "?" in post_login_base else "?"
-    params = urllib.parse.urlencode(
+    # Build the success redirect with the access token and new-user flag. The
+    # `/{provider}` segment is appended by _build_post_login_url to match the
+    # frontend route `auth/callback/:provider` (required param — see
+    # isnad-graph/frontend/src/App.tsx:57 and isnad-graph#824).
+    redirect_url = _build_post_login_url(
+        settings,
+        provider,
         {
             "token": access_token,
             "is_new_user": "1" if result.is_new_user else "0",
             # OAuth users are created with email_verified=True, so verification is
             # never needed via this flow — but we emit the flag for frontend parity.
             "needs_verification": "0",
-        }
+        },
     )
-    redirect_url = f"{post_login_base}{separator}{params}"
     response = RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
 
     # Refresh-token cookie: httpOnly + SameSite=Lax (Lax is required so the cookie

--- a/src/app/schemas/auth.py
+++ b/src/app/schemas/auth.py
@@ -81,21 +81,16 @@ class JWKSResponse(BaseModel):
 
 
 class OAuthLoginResponse(BaseModel):
-    """Response for OAuth login initiation — returns the authorization URL."""
+    """Response for OAuth login initiation — returns the authorization URL.
+
+    `state` and `code_verifier` are retained for backwards compatibility with
+    earlier SPA-driven callback flows. As of #66 the server-side GET callback
+    reads them from Redis; clients may ignore both fields.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     authorization_url: str
-    state: str
-    code_verifier: str
-
-
-class OAuthCallbackRequest(BaseModel):
-    """Request body for OAuth callback."""
-
-    model_config = ConfigDict(frozen=True)
-
-    code: str
     state: str
     code_verifier: str
 
@@ -110,18 +105,3 @@ class OAuthUserInfo(BaseModel):
     email: str | None = None
     display_name: str | None = None
     avatar_url: str | None = None
-
-
-class OAuthCallbackResponse(BaseModel):
-    """Response for OAuth callback — returns user data and a one-time authorization code."""
-
-    model_config = ConfigDict(frozen=True)
-
-    user_id: uuid.UUID
-    email: str
-    display_name: str | None = None
-    avatar_url: str | None = None
-    is_new_user: bool
-    provider: str
-    created_at: datetime
-    authorization_code: str

--- a/tests/test_oauth_callback_get.py
+++ b/tests/test_oauth_callback_get.py
@@ -1,0 +1,332 @@
+"""Integration tests for the server-side GET OAuth callback handler.
+
+Covers the flow added in #66 — the endpoint the OAuth provider redirects the
+user's browser to after consent. The POST callback that this replaces never
+had a test (nothing called it); this suite asserts the new contract.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.app.config import Settings, get_settings
+from src.app.database import get_db_session, get_redis
+from src.app.main import create_app
+from src.app.models.user import User
+from src.app.schemas.auth import OAuthUserInfo
+from src.app.services.user import OAuthUserResult
+
+
+def _test_settings() -> Settings:
+    return Settings(
+        DATABASE_URL="sqlite+aiosqlite:///:memory:",
+        JWT_PRIVATE_KEY="",
+        JWT_PUBLIC_KEY="",
+        AUTH_OAUTH_REDIRECT_BASE_URL="https://isnad-graph.noorinalabs.com",
+        AUTH_OAUTH_POST_LOGIN_URL="/auth/callback",
+        AUTH_OAUTH_STATE_TTL_SECONDS=600,
+        AUTH_OAUTH_REFRESH_COOKIE_SECURE=True,
+    )
+
+
+class _FakeRedis:
+    """Minimal in-memory stand-in for the async Redis client.
+
+    Implements only the methods the auth router actually calls on the callback
+    path (setex, getdel) so tests don't need a live Redis.
+    """
+
+    def __init__(self, seed: dict[str, str] | None = None) -> None:
+        self._store: dict[str, bytes] = {
+            k: v.encode() if isinstance(v, str) else v for k, v in (seed or {}).items()
+        }
+
+    async def setex(self, key: str, _ttl: int, value: str | bytes) -> None:
+        self._store[key] = value.encode() if isinstance(value, str) else value
+
+    async def getdel(self, key: str) -> bytes | None:
+        return self._store.pop(key, None)
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return _test_settings()
+
+
+@pytest.fixture
+def fake_user() -> User:
+    return User(
+        id=uuid.uuid4(),
+        email="mateo@example.com",
+        email_verified=True,
+        display_name="Mateo Test",
+        avatar_url=None,
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+async def client_factory(
+    settings: Settings,
+) -> AsyncGenerator[Any, None]:
+    """Factory yielding a client bound to a given FakeRedis + mocked DB session.
+
+    The callback handler doesn't actually execute SQL against the mock — the
+    service-layer calls are patched at module scope — but get_db_session must
+    still yield something so FastAPI's DI is satisfied.
+    """
+
+    async def _make(redis_seed: dict[str, str] | None = None) -> AsyncClient:
+        app = create_app()
+        app.dependency_overrides[get_settings] = lambda: settings
+        mock_db = AsyncMock()
+        # db.execute(...) must return something with .fetchall() for the roles query
+        roles_result = MagicMock()
+        roles_result.fetchall.return_value = []
+        mock_db.execute = AsyncMock(return_value=roles_result)
+
+        # Single FakeRedis shared across all requests made by this client. This is
+        # what matters for the replay test — prod uses one redis client per app.
+        shared_redis = _FakeRedis(redis_seed)
+
+        async def _db_dep() -> AsyncGenerator[Any, None]:
+            yield mock_db
+
+        async def _redis_dep() -> AsyncGenerator[Any, None]:
+            yield shared_redis
+
+        app.dependency_overrides[get_db_session] = _db_dep
+        app.dependency_overrides[get_redis] = _redis_dep
+
+        transport = ASGITransport(app=app)  # type: ignore[arg-type]
+        return AsyncClient(transport=transport, base_url="http://test", follow_redirects=False)
+
+    yield _make
+
+
+class TestOAuthCallbackGet:
+    @pytest.mark.asyncio
+    async def test_success_redirects_with_token_and_sets_cookie(
+        self,
+        client_factory: Any,
+        fake_user: User,
+    ) -> None:
+        """Happy path — state valid, code exchange works, user upserted, redirect 302."""
+        state = "valid-state-token"
+        seed = {
+            f"oauth_state:{state}": json.dumps(
+                {"provider": "google", "code_verifier": "pkce-verifier"}
+            ),
+        }
+
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g-123",
+                email="mateo@example.com",
+                display_name="Mateo Test",
+                avatar_url=None,
+            )
+        )
+
+        with (
+            patch(
+                "src.app.routers.auth.get_oauth_provider",
+                return_value=oauth_mock,
+            ),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake_user, is_new_user=False),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc123", "state": state},
+                )
+
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        parsed = urlparse(location)
+        assert parsed.path == "/auth/callback"
+        qs = parse_qs(parsed.query)
+        assert "token" in qs
+        assert qs["is_new_user"] == ["0"]
+        assert qs["needs_verification"] == ["0"]
+        # Refresh token must be set as an httpOnly cookie
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "refresh_token=" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "Secure" in set_cookie
+        assert "SameSite=lax" in set_cookie.lower() or "samesite=lax" in set_cookie.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_state_redirects_with_invalid_state_error(
+        self, client_factory: Any
+    ) -> None:
+        async with await client_factory({}) as client:
+            resp = await client.get(
+                "/auth/oauth/google/callback",
+                params={"code": "abc123", "state": "nope"},
+            )
+        assert resp.status_code == 302
+        assert "error=invalid_state" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_state_mismatched_provider_rejected(self, client_factory: Any) -> None:
+        """State was created for google, attacker tries the github callback route."""
+        state = "cross-provider-state"
+        seed = {
+            f"oauth_state:{state}": json.dumps({"provider": "google", "code_verifier": "verifier"}),
+        }
+        async with await client_factory(seed) as client:
+            resp = await client.get(
+                "/auth/oauth/github/callback",
+                params={"code": "abc", "state": state},
+            )
+        assert resp.status_code == 302
+        assert "error=invalid_state" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_provider_error_param_redirects_with_provider_denied(
+        self, client_factory: Any
+    ) -> None:
+        """User declined consent — provider redirects with ?error=access_denied."""
+        async with await client_factory({}) as client:
+            resp = await client.get(
+                "/auth/oauth/google/callback",
+                params={"error": "access_denied"},
+            )
+        assert resp.status_code == 302
+        assert "error=provider_denied" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_provider_redirects(self, client_factory: Any) -> None:
+        async with await client_factory({}) as client:
+            resp = await client.get(
+                "/auth/oauth/myspace/callback",
+                params={"code": "abc", "state": "anything"},
+            )
+        assert resp.status_code == 302
+        assert "error=unsupported_provider" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_failure_redirects_with_error(self, client_factory: Any) -> None:
+        state = "valid-state"
+        seed = {
+            f"oauth_state:{state}": json.dumps({"provider": "google", "code_verifier": "verifier"}),
+        }
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        with patch(
+            "src.app.routers.auth.get_oauth_provider",
+            return_value=oauth_mock,
+        ):
+            async with await client_factory(seed) as client:
+                resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc", "state": state},
+                )
+        assert resp.status_code == 302
+        assert "error=oauth_exchange_failed" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_state_is_consumed_exactly_once(self, client_factory: Any) -> None:
+        """Replaying the callback URL with the same state must fail the second time."""
+        state = "replay-state"
+        seed = {
+            f"oauth_state:{state}": json.dumps({"provider": "google", "code_verifier": "verifier"}),
+        }
+        oauth_mock = MagicMock()
+        # Both calls would succeed at the provider level — the guard is at the state check.
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "t"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g",
+                email="e@e.com",
+                display_name=None,
+                avatar_url=None,
+            )
+        )
+        fake = User(
+            id=uuid.uuid4(),
+            email="e@e.com",
+            email_verified=True,
+            display_name=None,
+            is_active=True,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        with (
+            patch("src.app.routers.auth.get_oauth_provider", return_value=oauth_mock),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake, is_new_user=True),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                first = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc", "state": state},
+                )
+                assert first.status_code == 302
+                assert "token=" in first.headers["location"]
+
+                # Same client instance — the FakeRedis is shared; state key was consumed.
+                second = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc", "state": state},
+                )
+                assert second.status_code == 302
+                assert "error=invalid_state" in second.headers["location"]
+
+
+class TestPostCallbackRemoved:
+    """The POST callback was dead code (no frontend caller); #66 removed it."""
+
+    @pytest.mark.asyncio
+    async def test_post_callback_returns_405(self, client_factory: Any) -> None:
+        async with await client_factory({}) as client:
+            resp = await client.post(
+                "/auth/oauth/google/callback",
+                json={"code": "a", "state": "b", "code_verifier": "c"},
+            )
+        # FastAPI replies 405 when only GET is registered on the path.
+        assert resp.status_code == 405

--- a/tests/test_oauth_callback_get.py
+++ b/tests/test_oauth_callback_get.py
@@ -172,7 +172,10 @@ class TestOAuthCallbackGet:
         assert resp.status_code == 302
         location = resp.headers["location"]
         parsed = urlparse(location)
-        assert parsed.path == "/auth/callback"
+        # Path must include the provider segment to match the frontend React
+        # Router route `auth/callback/:provider`. Regression guard for the Anya
+        # must-fix on PR#67.
+        assert parsed.path == "/auth/callback/google"
         qs = parse_qs(parsed.query)
         assert "token" in qs
         assert qs["is_new_user"] == ["0"]
@@ -194,6 +197,10 @@ class TestOAuthCallbackGet:
                 params={"code": "abc123", "state": "nope"},
             )
         assert resp.status_code == 302
+        # Error redirects must also carry the provider segment so the frontend
+        # route matches and the `error=` param is read.
+        parsed = urlparse(resp.headers["location"])
+        assert parsed.path == "/auth/callback/google"
         assert "error=invalid_state" in resp.headers["location"]
 
     @pytest.mark.asyncio
@@ -254,6 +261,41 @@ class TestOAuthCallbackGet:
                 )
         assert resp.status_code == 302
         assert "error=oauth_exchange_failed" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_user_info_failure_redirects_with_error(self, client_factory: Any) -> None:
+        """Provider returns tokens but user-info fetch fails — distinct from exchange_failure.
+
+        Filed under the review-requested gap on #70. Mirrors the exchange test but
+        keeps exchange_code succeeding so we exercise the second try/except branch.
+        """
+        state = "valid-state-ui"
+        seed = {
+            f"oauth_state:{state}": json.dumps({"provider": "google", "code_verifier": "verifier"}),
+        }
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(side_effect=RuntimeError("userinfo 500"))
+
+        with patch(
+            "src.app.routers.auth.get_oauth_provider",
+            return_value=oauth_mock,
+        ):
+            async with await client_factory(seed) as client:
+                resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc", "state": state},
+                )
+        assert resp.status_code == 302
+        # Currently aliased to the same error code as exchange failures — the
+        # frontend only distinguishes "provider misbehaved" from the other cases.
+        # If that ever splits, this test will catch the unintentional collapse.
+        parsed = urlparse(resp.headers["location"])
+        assert parsed.path == "/auth/callback/google"
+        assert "error=oauth_exchange_failed" in resp.headers["location"]
+        # exchange_code must have been called (so we're truly testing the second branch)
+        oauth_mock.exchange_code.assert_awaited_once()
+        oauth_mock.get_user_info.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_state_is_consumed_exactly_once(self, client_factory: Any) -> None:


### PR DESCRIPTION
Closes #66. Surfaced 2026-04-19 by first end-to-end OAuth test on prod after #145 cutover. Owner picked Option A from #66.

## Summary

- Replace POST-only OAuth callback with a GET handler (standard server-side flow)
- Store OAuth state + PKCE code_verifier in Redis (single-use via `getdel`) instead of round-tripping through the client
- Mint access + refresh tokens in-handler; redirect to frontend `AuthCallbackPage` contract (`?token=...&is_new_user=...&needs_verification=...`) with refresh token as an httpOnly Secure SameSite=Lax cookie
- Redirect to `AUTH_OAUTH_POST_LOGIN_URL` with `?error=<code>` on every failure path (invalid state, provider denial, exchange failure, email mismatch, unsupported provider)
- Add three settings: `AUTH_OAUTH_POST_LOGIN_URL` (default `/auth/callback`), `AUTH_OAUTH_STATE_TTL_SECONDS` (default 600), `AUTH_OAUTH_REFRESH_COOKIE_SECURE` (default true)

## Implementation notes

- **POST callback removed.** Searched the isnad-graph frontend: the only consumer of OAuth endpoints is `LoginPage.tsx`, which calls `GET /oauth/{provider}/login` and redirects the browser to `authorization_url`. Nothing POSTs to the callback. It was dead code that actively misled the root-cause diagnosis, so it's gone. Net code reduction once schemas are cleaned up (`OAuthCallbackRequest` + `OAuthCallbackResponse` deleted).
- **State storage.** `oauth_login` now stashes `{provider, code_verifier}` in Redis keyed by `oauth_state:<state>` with a 10-minute TTL. The GET callback pulls it via `getdel` (atomic pop) so replay of the same callback URL fails the state check. Tampering with the `{provider}` path segment is caught by comparing it to the provider stored alongside the state.
- **Existing service functions reused, not refactored.** `oauth.exchange_code`, `oauth.get_user_info`, `find_or_create_oauth_user`, `create_access_token`, `create_refresh_token`, `store_refresh_token`, `get_subscription_status` — all unchanged. The handler is the only new caller. I considered extracting a `oauth_service.exchange_and_authenticate()` seam but there's no second caller to justify it after dropping POST.
- **Error surface is browser-readable.** Every exit path redirects rather than returning JSON (users hit this URL via browser, JSON responses would be a dead end). Error codes (`invalid_state`, `oauth_exchange_failed`, `provider_denied`, `email_mismatch`, `unsupported_provider`) match the existing `ERROR_MESSAGES` map in `frontend/src/pages/AuthCallbackPage.tsx` where overlapping.
- **Cookie security.** `httpOnly=true`, `Secure=<env-gated>`, `SameSite=Lax`, `Path=/auth`. Lax (not Strict) is required — Strict would drop the cookie on the initial cross-site redirect from the OAuth provider back to us. Scoped to `/auth` because only `/auth/token/refresh` and `/auth/token/revoke` read it.
- **OAuth users always have `email_verified=True`** (existing behavior in `find_or_create_oauth_user`), so `needs_verification=0` is always emitted for parity with the frontend contract even though it's not a meaningful branch right now.

## Test plan

- [x] `make test` — 193 tests pass (8 new in `test_oauth_callback_get.py` plus existing 185)
- [x] `make lint` — clean
- [x] `make format` — clean
- [x] New test coverage: happy path (302 + token + httpOnly cookie), missing state, cross-provider state tampering, provider `?error=access_denied`, unsupported provider, exchange failure, state consumed exactly once (replay blocked), POST callback returns 405 (the old route is gone)
- [ ] Post-merge: deploy and click "Sign in with Google" on https://isnad-graph.noorinalabs.com/ — should land signed in on the frontend
- [ ] Post-merge: verify GitHub flow
- [ ] Post-merge: verify prod `.env` has `AUTH_OAUTH_POST_LOGIN_URL` and `AUTH_OAUTH_REFRESH_COOKIE_SECURE=true` (defaults are production-safe)
