### PR TITLE
feat(auth): OAUTH_PROVIDER_BASE_URL_OVERRIDE setting for integration tests (noorinalabs-main#135)

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,5 +1,7 @@
 from functools import lru_cache
+from urllib.parse import urlparse
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -73,6 +75,13 @@ class Settings(BaseSettings):
     # OAuth — Redirect base URL
     AUTH_OAUTH_REDIRECT_BASE_URL: str = "http://localhost:8000"
 
+    # OAuth — Provider base URL override (integration testing only)
+    # When set, overrides provider OAuth endpoint hosts for integration testing.
+    # Format: scheme+host (e.g., "http://fake_oauth:8080"). Rewrites authorize-URL,
+    # token-endpoint, and userinfo-endpoint hosts to this base — paths are preserved.
+    # Leave unset in production.
+    OAUTH_PROVIDER_BASE_URL_OVERRIDE: str | None = None
+
     # OAuth — Server-side flow (GET callback)
     # BASE path for the frontend destination after successful OAuth. The handler
     # always appends `/{provider}` to match the frontend route
@@ -89,6 +98,20 @@ class Settings(BaseSettings):
     AUTH_OAUTH_REFRESH_COOKIE_SECURE: bool = True
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+    @field_validator("OAUTH_PROVIDER_BASE_URL_OVERRIDE")
+    @classmethod
+    def _validate_oauth_provider_base_url_override(cls, v: str | None) -> str | None:
+        if v is None or v == "":
+            return None
+        parsed = urlparse(v)
+        if not parsed.scheme or not parsed.netloc:
+            msg = (
+                "OAUTH_PROVIDER_BASE_URL_OVERRIDE must include scheme and host "
+                f"(e.g., 'http://fake_oauth:8080'), got: {v!r}"
+            )
+            raise ValueError(msg)
+        return v
 
 
 @lru_cache

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,12 +1,20 @@
 from functools import lru_cache
+from typing import Self
 from urllib.parse import urlparse
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+_ALLOWED_OVERRIDE_SCHEMES = frozenset({"http", "https"})
+_PROD_LIKE_ENVIRONMENTS = frozenset({"production", "staging"})
+_ALLOWED_ENVIRONMENTS = frozenset({"development", "test", "staging", "production"})
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
+
+    # Deployment environment — gates security-sensitive settings
+    ENVIRONMENT: str = "development"
 
     # Database
     DATABASE_URL: str = (
@@ -99,6 +107,14 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
+    @field_validator("ENVIRONMENT")
+    @classmethod
+    def _validate_environment(cls, v: str) -> str:
+        if v not in _ALLOWED_ENVIRONMENTS:
+            msg = f"ENVIRONMENT must be one of {sorted(_ALLOWED_ENVIRONMENTS)}, got: {v!r}"
+            raise ValueError(msg)
+        return v
+
     @field_validator("OAUTH_PROVIDER_BASE_URL_OVERRIDE")
     @classmethod
     def _validate_oauth_provider_base_url_override(cls, v: str | None) -> str | None:
@@ -111,7 +127,32 @@ class Settings(BaseSettings):
                 f"(e.g., 'http://fake_oauth:8080'), got: {v!r}"
             )
             raise ValueError(msg)
+        if parsed.scheme not in _ALLOWED_OVERRIDE_SCHEMES:
+            msg = (
+                "OAUTH_PROVIDER_BASE_URL_OVERRIDE scheme must be one of "
+                f"{sorted(_ALLOWED_OVERRIDE_SCHEMES)}, got: {parsed.scheme!r}"
+            )
+            raise ValueError(msg)
         return v
+
+    @model_validator(mode="after")
+    def _guard_oauth_provider_base_url_override(self) -> Self:
+        override = self.OAUTH_PROVIDER_BASE_URL_OVERRIDE
+        if override is None:
+            return self
+        if self.ENVIRONMENT in _PROD_LIKE_ENVIRONMENTS:
+            msg = (
+                "OAUTH_PROVIDER_BASE_URL_OVERRIDE must not be set in "
+                "production/staging environments"
+            )
+            raise ValueError(msg)
+        if self.ENVIRONMENT != "test" and urlparse(override).scheme != "https":
+            msg = (
+                "OAUTH_PROVIDER_BASE_URL_OVERRIDE must use https:// outside "
+                "ENVIRONMENT=test (no HTTP downgrade)"
+            )
+            raise ValueError(msg)
+        return self
 
 
 @lru_cache

--- a/src/app/services/oauth.py
+++ b/src/app/services/oauth.py
@@ -8,6 +8,7 @@ import secrets
 from abc import ABC, abstractmethod
 from enum import StrEnum
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -28,6 +29,22 @@ def generate_pkce_pair() -> tuple[str, str]:
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
     return code_verifier, code_challenge
+
+
+def _maybe_override(url: str, override: str | None) -> str:
+    """Rewrite the scheme+host of `url` to match `override` when set.
+
+    Path, query, and fragment are preserved so the fake provider only needs to
+    mirror the real provider's paths. No-op when `override` is None/empty.
+    """
+    if not override:
+        return url
+    parsed = urlparse(url)
+    override_parsed = urlparse(override)
+    return parsed._replace(
+        scheme=override_parsed.scheme,
+        netloc=override_parsed.netloc,
+    ).geturl()
 
 
 class BaseOAuthProvider(ABC):
@@ -61,6 +78,7 @@ class GoogleOAuthProvider(BaseOAuthProvider):
     def __init__(self, settings: Settings) -> None:
         self.client_id = settings.AUTH_GOOGLE_CLIENT_ID
         self.client_secret = settings.AUTH_GOOGLE_CLIENT_SECRET
+        self.base_url_override = settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE
 
     def get_authorization_url(self, state: str, code_challenge: str, redirect_uri: str) -> str:
         params = {
@@ -73,14 +91,15 @@ class GoogleOAuthProvider(BaseOAuthProvider):
             "code_challenge_method": "S256",
             "access_type": "offline",
         }
-        return f"https://accounts.google.com/o/oauth2/v2/auth?{_urlencode(params)}"
+        url = f"https://accounts.google.com/o/oauth2/v2/auth?{_urlencode(params)}"
+        return _maybe_override(url, self.base_url_override)
 
     async def exchange_code(
         self, code: str, code_verifier: str, redirect_uri: str
     ) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                "https://oauth2.googleapis.com/token",
+                _maybe_override("https://oauth2.googleapis.com/token", self.base_url_override),
                 data={
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
@@ -96,7 +115,9 @@ class GoogleOAuthProvider(BaseOAuthProvider):
     async def get_user_info(self, access_token: str) -> OAuthUserInfo:
         async with httpx.AsyncClient() as client:
             resp = await client.get(
-                "https://www.googleapis.com/oauth2/v3/userinfo",
+                _maybe_override(
+                    "https://www.googleapis.com/oauth2/v3/userinfo", self.base_url_override
+                ),
                 headers={"Authorization": f"Bearer {access_token}"},
             )
             resp.raise_for_status()
@@ -118,6 +139,7 @@ class GitHubOAuthProvider(BaseOAuthProvider):
     def __init__(self, settings: Settings) -> None:
         self.client_id = settings.AUTH_GITHUB_CLIENT_ID
         self.client_secret = settings.AUTH_GITHUB_CLIENT_SECRET
+        self.base_url_override = settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE
 
     def get_authorization_url(self, state: str, code_challenge: str, redirect_uri: str) -> str:
         params = {
@@ -128,14 +150,17 @@ class GitHubOAuthProvider(BaseOAuthProvider):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
-        return f"https://github.com/login/oauth/authorize?{_urlencode(params)}"
+        url = f"https://github.com/login/oauth/authorize?{_urlencode(params)}"
+        return _maybe_override(url, self.base_url_override)
 
     async def exchange_code(
         self, code: str, code_verifier: str, redirect_uri: str
     ) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                "https://github.com/login/oauth/access_token",
+                _maybe_override(
+                    "https://github.com/login/oauth/access_token", self.base_url_override
+                ),
                 data={
                     "client_id": self.client_id,
                     "client_secret": self.client_secret,
@@ -151,7 +176,7 @@ class GitHubOAuthProvider(BaseOAuthProvider):
     async def get_user_info(self, access_token: str) -> OAuthUserInfo:
         async with httpx.AsyncClient() as client:
             user_resp = await client.get(
-                "https://api.github.com/user",
+                _maybe_override("https://api.github.com/user", self.base_url_override),
                 headers={
                     "Authorization": f"Bearer {access_token}",
                     "Accept": "application/vnd.github+json",
@@ -164,7 +189,7 @@ class GitHubOAuthProvider(BaseOAuthProvider):
             email = user_data.get("email")
             if not email:
                 email_resp = await client.get(
-                    "https://api.github.com/user/emails",
+                    _maybe_override("https://api.github.com/user/emails", self.base_url_override),
                     headers={
                         "Authorization": f"Bearer {access_token}",
                         "Accept": "application/vnd.github+json",
@@ -196,6 +221,7 @@ class AppleOAuthProvider(BaseOAuthProvider):
         self.team_id = settings.AUTH_APPLE_TEAM_ID
         self.key_id = settings.AUTH_APPLE_KEY_ID
         self.private_key = settings.AUTH_APPLE_PRIVATE_KEY
+        self.base_url_override = settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE
 
     def _generate_client_secret(self) -> str:
         """Generate a short-lived JWT client secret for Apple."""
@@ -229,7 +255,8 @@ class AppleOAuthProvider(BaseOAuthProvider):
             "code_challenge_method": "S256",
             "response_mode": "form_post",
         }
-        return f"https://appleid.apple.com/auth/authorize?{_urlencode(params)}"
+        url = f"https://appleid.apple.com/auth/authorize?{_urlencode(params)}"
+        return _maybe_override(url, self.base_url_override)
 
     async def exchange_code(
         self, code: str, code_verifier: str, redirect_uri: str
@@ -237,7 +264,7 @@ class AppleOAuthProvider(BaseOAuthProvider):
         client_secret = self._generate_client_secret()
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                "https://appleid.apple.com/auth/token",
+                _maybe_override("https://appleid.apple.com/auth/token", self.base_url_override),
                 data={
                     "client_id": self.client_id,
                     "client_secret": client_secret,
@@ -261,7 +288,9 @@ class AppleOAuthProvider(BaseOAuthProvider):
 
         # Fetch Apple's public keys and verify the id_token signature
         async with httpx.AsyncClient() as client:
-            jwks_resp = await client.get("https://appleid.apple.com/auth/keys")
+            jwks_resp = await client.get(
+                _maybe_override("https://appleid.apple.com/auth/keys", self.base_url_override)
+            )
             jwks_resp.raise_for_status()
             apple_jwks = jwks_resp.json()
 
@@ -289,6 +318,7 @@ class FacebookOAuthProvider(BaseOAuthProvider):
     def __init__(self, settings: Settings) -> None:
         self.app_id = settings.AUTH_FACEBOOK_APP_ID
         self.app_secret = settings.AUTH_FACEBOOK_APP_SECRET
+        self.base_url_override = settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE
 
     def get_authorization_url(self, state: str, code_challenge: str, redirect_uri: str) -> str:
         params = {
@@ -300,14 +330,18 @@ class FacebookOAuthProvider(BaseOAuthProvider):
             "code_challenge_method": "S256",
             "response_type": "code",
         }
-        return f"https://www.facebook.com/v19.0/dialog/oauth?{_urlencode(params)}"
+        url = f"https://www.facebook.com/v19.0/dialog/oauth?{_urlencode(params)}"
+        return _maybe_override(url, self.base_url_override)
 
     async def exchange_code(
         self, code: str, code_verifier: str, redirect_uri: str
     ) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
             resp = await client.get(
-                "https://graph.facebook.com/v19.0/oauth/access_token",
+                _maybe_override(
+                    "https://graph.facebook.com/v19.0/oauth/access_token",
+                    self.base_url_override,
+                ),
                 params={
                     "client_id": self.app_id,
                     "client_secret": self.app_secret,
@@ -322,7 +356,7 @@ class FacebookOAuthProvider(BaseOAuthProvider):
     async def get_user_info(self, access_token: str) -> OAuthUserInfo:
         async with httpx.AsyncClient() as client:
             resp = await client.get(
-                "https://graph.facebook.com/v19.0/me",
+                _maybe_override("https://graph.facebook.com/v19.0/me", self.base_url_override),
                 params={
                     "fields": "id,name,email,picture.type(large)",
                     "access_token": access_token,

--- a/tests/test_oauth_provider_base_url_override.py
+++ b/tests/test_oauth_provider_base_url_override.py
@@ -1,0 +1,358 @@
+"""Tests for OAUTH_PROVIDER_BASE_URL_OVERRIDE — integration-testing hook.
+
+Covers the `_maybe_override` helper, the Settings validator, and each provider's
+URL surfaces (authorize URL, token endpoint, userinfo endpoint, JWKS).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
+
+import pytest
+from pydantic import ValidationError
+
+from src.app.config import Settings
+from src.app.services.oauth import (
+    AppleOAuthProvider,
+    FacebookOAuthProvider,
+    GitHubOAuthProvider,
+    GoogleOAuthProvider,
+    _maybe_override,
+)
+
+
+def _make_settings(**overrides: str | None) -> Settings:
+    """Create a Settings instance with OAuth defaults filled in."""
+    defaults: dict[str, str | None] = {
+        "AUTH_GOOGLE_CLIENT_ID": "google-client-id",
+        "AUTH_GOOGLE_CLIENT_SECRET": "google-secret",
+        "AUTH_GITHUB_CLIENT_ID": "github-client-id",
+        "AUTH_GITHUB_CLIENT_SECRET": "github-secret",
+        "AUTH_APPLE_CLIENT_ID": "apple-client-id",
+        "AUTH_APPLE_TEAM_ID": "TEAMID",
+        "AUTH_APPLE_KEY_ID": "KEYID",
+        "AUTH_APPLE_PRIVATE_KEY": "fake-private-key",
+        "AUTH_FACEBOOK_APP_ID": "fb-app-id",
+        "AUTH_FACEBOOK_APP_SECRET": "fb-secret",
+        "AUTH_OAUTH_REDIRECT_BASE_URL": "http://localhost:8000",
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestMaybeOverrideHelper:
+    def test_returns_unchanged_when_override_none(self) -> None:
+        assert (
+            _maybe_override("https://accounts.google.com/o/oauth2/v2/auth", None)
+            == "https://accounts.google.com/o/oauth2/v2/auth"
+        )
+
+    def test_returns_unchanged_when_override_empty_string(self) -> None:
+        assert (
+            _maybe_override("https://accounts.google.com/o/oauth2/v2/auth", "")
+            == "https://accounts.google.com/o/oauth2/v2/auth"
+        )
+
+    def test_rewrites_host_preserves_path(self) -> None:
+        rewritten = _maybe_override(
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            "http://fake_oauth:8080",
+        )
+        parsed = urlparse(rewritten)
+        assert parsed.scheme == "http"
+        assert parsed.netloc == "fake_oauth:8080"
+        assert parsed.path == "/o/oauth2/v2/auth"
+
+    def test_preserves_query_string(self) -> None:
+        rewritten = _maybe_override(
+            "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc&state=xyz",
+            "http://fake_oauth:8080",
+        )
+        parsed = urlparse(rewritten)
+        assert parsed.netloc == "fake_oauth:8080"
+        assert parsed.path == "/o/oauth2/v2/auth"
+        assert "client_id=abc" in parsed.query
+        assert "state=xyz" in parsed.query
+
+    def test_scheme_follows_override(self) -> None:
+        # Production URL is https; override specifies http → scheme becomes http
+        rewritten = _maybe_override(
+            "https://oauth2.googleapis.com/token",
+            "http://fake:9999",
+        )
+        assert rewritten.startswith("http://fake:9999/")
+
+        # And vice versa
+        rewritten = _maybe_override(
+            "http://example.com/token",
+            "https://secure.example:443",
+        )
+        assert rewritten.startswith("https://secure.example:443/")
+
+
+class TestSettingsValidator:
+    def test_override_unset_is_none(self) -> None:
+        settings = _make_settings()
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE is None
+
+    def test_override_empty_string_becomes_none(self) -> None:
+        settings = _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="")
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE is None
+
+    def test_override_valid_value_accepted(self) -> None:
+        settings = _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake_oauth:8080")
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE == "http://fake_oauth:8080"
+
+    def test_override_https_scheme_accepted(self) -> None:
+        settings = _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake.example.com")
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE == "https://fake.example.com"
+
+    def test_override_missing_scheme_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="fake_oauth:8080")
+        assert "scheme and host" in str(exc.value)
+
+    def test_override_bare_host_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="fake_oauth")
+        assert "scheme and host" in str(exc.value)
+
+    def test_override_scheme_only_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://")
+        assert "scheme and host" in str(exc.value)
+
+
+class TestGoogleOverride:
+    def test_authorization_url_override_unset(self) -> None:
+        provider = GoogleOAuthProvider(_make_settings())
+        url = provider.get_authorization_url("s", "c", "http://localhost/cb")
+        assert urlparse(url).netloc == "accounts.google.com"
+
+    def test_authorization_url_override_set(self) -> None:
+        provider = GoogleOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        url = provider.get_authorization_url("s", "c", "http://localhost/cb")
+        parsed = urlparse(url)
+        assert parsed.scheme == "http"
+        assert parsed.netloc == "fake:8080"
+        assert parsed.path == "/o/oauth2/v2/auth"
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_override_set_rewrites_token_host(self) -> None:
+        provider = GoogleOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "x"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.exchange_code("code", "verifier", "http://localhost/cb")
+
+            called_url = mock_client.post.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/token"
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_override_set_rewrites_userinfo_host(self) -> None:
+        provider = GoogleOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"sub": "u1", "email": "e@example.com"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.get_user_info("token")
+
+            called_url = mock_client.get.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/oauth2/v3/userinfo"
+
+
+class TestGitHubOverride:
+    def test_authorization_url_override_set(self) -> None:
+        provider = GitHubOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        url = provider.get_authorization_url("s", "c", "http://localhost/cb")
+        parsed = urlparse(url)
+        assert parsed.netloc == "fake:8080"
+        assert parsed.path == "/login/oauth/authorize"
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_override_set(self) -> None:
+        provider = GitHubOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "x"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.exchange_code("code", "verifier", "http://localhost/cb")
+
+            called_url = mock_client.post.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/login/oauth/access_token"
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_override_set_rewrites_user_and_emails(self) -> None:
+        provider = GitHubOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        user_resp = MagicMock()
+        user_resp.json.return_value = {
+            "id": 1,
+            "email": None,
+            "name": "N",
+            "login": "l",
+            "avatar_url": None,
+        }
+        user_resp.raise_for_status = MagicMock()
+
+        emails_resp = MagicMock()
+        emails_resp.json.return_value = [
+            {"email": "p@example.com", "primary": True, "verified": True},
+        ]
+        emails_resp.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[user_resp, emails_resp])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.get_user_info("token")
+
+            user_url = mock_client.get.call_args_list[0][0][0]
+            emails_url = mock_client.get.call_args_list[1][0][0]
+            assert urlparse(user_url).netloc == "fake:8080"
+            assert urlparse(user_url).path == "/user"
+            assert urlparse(emails_url).netloc == "fake:8080"
+            assert urlparse(emails_url).path == "/user/emails"
+
+
+class TestAppleOverride:
+    def test_authorization_url_override_set(self) -> None:
+        provider = AppleOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        url = provider.get_authorization_url("s", "c", "http://localhost/cb")
+        parsed = urlparse(url)
+        assert parsed.netloc == "fake:8080"
+        assert parsed.path == "/auth/authorize"
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_rewrites_jwks_host(self) -> None:
+        provider = AppleOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        jwks_resp = MagicMock()
+        jwks_resp.json.return_value = {"keys": [{"kty": "RSA", "kid": "t"}]}
+        jwks_resp.raise_for_status = MagicMock()
+
+        with (
+            patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls,
+            patch("jose.jwt.decode") as mock_decode,
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=jwks_resp)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            mock_decode.return_value = {"sub": "a1", "email": "a@example.com"}
+
+            await provider.get_user_info("fake-id-token")
+
+            called_url = mock_client.get.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/auth/keys"
+
+
+class TestFacebookOverride:
+    def test_authorization_url_override_set(self) -> None:
+        provider = FacebookOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        url = provider.get_authorization_url("s", "c", "http://localhost/cb")
+        parsed = urlparse(url)
+        assert parsed.netloc == "fake:8080"
+        assert parsed.path == "/v19.0/dialog/oauth"
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_override_set(self) -> None:
+        provider = FacebookOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "x"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.exchange_code("code", "verifier", "http://localhost/cb")
+
+            called_url = mock_client.get.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/v19.0/oauth/access_token"
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_override_set(self) -> None:
+        provider = FacebookOAuthProvider(
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080")
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "f1",
+            "name": "F",
+            "email": "f@example.com",
+            "picture": {"data": {"url": "", "is_silhouette": True}},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("src.app.services.oauth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.get_user_info("token")
+
+            called_url = mock_client.get.call_args[0][0]
+            parsed = urlparse(called_url)
+            assert parsed.netloc == "fake:8080"
+            assert parsed.path == "/v19.0/me"

--- a/tests/test_oauth_provider_base_url_override.py
+++ b/tests/test_oauth_provider_base_url_override.py
@@ -23,8 +23,14 @@ from src.app.services.oauth import (
 
 
 def _make_settings(**overrides: str | None) -> Settings:
-    """Create a Settings instance with OAuth defaults filled in."""
+    """Create a Settings instance with OAuth defaults filled in.
+
+    Defaults to ENVIRONMENT=test so the OAUTH_PROVIDER_BASE_URL_OVERRIDE guard
+    allows http:// overrides during integration tests. Pass ENVIRONMENT=... to
+    override.
+    """
     defaults: dict[str, str | None] = {
+        "ENVIRONMENT": "test",
         "AUTH_GOOGLE_CLIENT_ID": "google-client-id",
         "AUTH_GOOGLE_CLIENT_SECRET": "google-secret",
         "AUTH_GITHUB_CLIENT_ID": "github-client-id",
@@ -122,6 +128,94 @@ class TestSettingsValidator:
         with pytest.raises(ValidationError) as exc:
             _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://")
         assert "scheme and host" in str(exc.value)
+
+
+class TestEnvironmentGuard:
+    """Cross-field guards preventing override misuse in production/staging."""
+
+    def test_production_with_override_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(
+                ENVIRONMENT="production",
+                OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake.example.com",
+            )
+        assert "production/staging" in str(exc.value)
+
+    def test_staging_with_override_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(
+                ENVIRONMENT="staging",
+                OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake.example.com",
+            )
+        assert "production/staging" in str(exc.value)
+
+    def test_production_without_override_loads(self) -> None:
+        settings = _make_settings(ENVIRONMENT="production")
+        assert settings.ENVIRONMENT == "production"
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE is None
+
+    def test_production_with_https_override_still_raises(self) -> None:
+        # Blocker 1 precedence: override is forbidden in prod regardless of scheme.
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(
+                ENVIRONMENT="production",
+                OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake.example.com/o/oauth2",
+            )
+        assert "production/staging" in str(exc.value)
+
+    def test_development_with_http_override_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(
+                ENVIRONMENT="development",
+                OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080",
+            )
+        assert "https://" in str(exc.value)
+
+    def test_development_with_https_override_loads(self) -> None:
+        settings = _make_settings(
+            ENVIRONMENT="development",
+            OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake.example.com",
+        )
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE == "https://fake.example.com"
+
+    def test_test_environment_with_http_override_loads(self) -> None:
+        settings = _make_settings(
+            ENVIRONMENT="test",
+            OAUTH_PROVIDER_BASE_URL_OVERRIDE="http://fake:8080",
+        )
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE == "http://fake:8080"
+
+    def test_test_environment_with_https_override_loads(self) -> None:
+        settings = _make_settings(
+            ENVIRONMENT="test",
+            OAUTH_PROVIDER_BASE_URL_OVERRIDE="https://fake:8080",
+        )
+        assert settings.OAUTH_PROVIDER_BASE_URL_OVERRIDE == "https://fake:8080"
+
+
+class TestSchemeWhitelist:
+    """Field-level whitelist rejecting non-http(s) schemes that urlparse accepts."""
+
+    def test_file_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="file://host/x")
+        assert "scheme" in str(exc.value)
+
+    def test_javascript_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="javascript://alert(1)")
+        assert "scheme" in str(exc.value)
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="ftp://host:21")
+        assert "scheme" in str(exc.value)
+
+    def test_data_uri_rejected(self) -> None:
+        # data: URIs have no netloc → caught by the "scheme and host" guard.
+        with pytest.raises(ValidationError) as exc:
+            _make_settings(OAUTH_PROVIDER_BASE_URL_OVERRIDE="data:text/plain,x")
+        assert "scheme and host" in str(exc.value) or "scheme" in str(exc.value)
 
 
 class TestGoogleOverride:


### PR DESCRIPTION
## Summary

- Implements the **user-service half** of parent-repo meta-issue [noorinalabs-main#135](https://github.com/noorinalabs/noorinalabs-main/issues/135).
- Adds optional `OAUTH_PROVIDER_BASE_URL_OVERRIDE` Pydantic v2 Settings field.
- When set to `scheme+host` (e.g., `http://fake_oauth:8080`), every outbound OAuth URL in `src/app/services/oauth.py` has its scheme+host rewritten; paths are preserved so a fake provider only needs to mirror the real paths.
- Purely additive — no existing provider paths, scopes, or flow logic changed.
- Intended for integration testing against a fake_oauth container introduced by the noorinalabs-main#49 integration-test suite; **leave unset in production**.

## Out of scope (separate PR in deploy repo)

The fake_oauth container + docker-compose.integration.yml wiring is a separate workstream in [noorinalabs-deploy](https://github.com/noorinalabs/noorinalabs-deploy), per the parent meta-issue.

## Call sites touched

`src/app/services/oauth.py`:
- Google: authorize URL, `/token`, `/oauth2/v3/userinfo`
- GitHub: `/login/oauth/authorize`, `/login/oauth/access_token`, `/user`, `/user/emails`
- Apple: `/auth/authorize`, `/auth/token`, `/auth/keys` (JWKS)
- Facebook: `/v19.0/dialog/oauth`, `/v19.0/oauth/access_token`, `/v19.0/me`

### Intentionally NOT overridden

Apple `AppleOAuthProvider._generate_client_secret` (`aud=https://appleid.apple.com`) and `get_user_info` (`issuer=https://appleid.apple.com`) are **signed-JWT claim values**, not URLs we fetch. The fake provider is expected to sign its id_tokens with the real issuer value so verification logic stays untouched.

## Validation

- Pydantic v2 `field_validator` on `OAUTH_PROVIDER_BASE_URL_OVERRIDE`: empty string → None; missing scheme or missing host → fail-fast `ValidationError` at Settings load with a clear message naming the field and the invalid value.

## Tests

New file: `tests/test_oauth_provider_base_url_override.py` (24 tests).

- Helper `_maybe_override`: unset/empty → no-op; set → host rewritten, path/query preserved; scheme follows override (both directions).
- Settings validator: unset→None, empty→None, valid http, valid https, malformed (no scheme / bare host / scheme-only) → `ValidationError`.
- Per-provider (Google, GitHub, Apple, Facebook): authorize URL, token endpoint, userinfo endpoint, Apple JWKS — all verified via `urlparse` to rewrite netloc while preserving path.

```
tests/test_oauth_provider_base_url_override.py  24 passed
tests/test_oauth_providers.py                   18 passed (unchanged, still green)
```

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [x] `uv run mypy src/app/config.py src/app/services/oauth.py` — clean (on touched files)
- [x] `uv run pytest tests/test_oauth_provider_base_url_override.py tests/test_oauth_providers.py -v` — 42 passed
- [ ] Integration smoke from the deploy-repo PR once fake_oauth lands (out of scope here)

## Notes for reviewers

**TechDebt: #76** — `make check` surfaces two pre-existing `unused-ignore` mypy errors in `src/app/services/token.py` on `main` (confirmed via `git checkout origin/main -- src/app/services/token.py && uv run mypy …`). Not introduced by this change; filed separately as user-service#76 to keep this PR scoped.

Requested reviewers (user-service team per charter, not parent org):
- **Anya Kowalczyk** — Tech Lead
- **Idris Yusuf** — Security Engineer (OAuth config touches security surface; sanity-check on override semantics and Apple claim-value reasoning)

Charter format on review replies: `RequestOrReplied: Approved` on verdicts; `TechDebt: <none | #N>` on every comment.