### PR TITLE
fix(alembic): add merge migration to collapse three heads to one (#63)

### DIFF
--- a/alembic/versions/0040_merge_multi_heads.py
+++ b/alembic/versions/0040_merge_multi_heads.py
@@ -1,0 +1,26 @@
+"""Merge multi-heads to single head.
+
+Revision ID: 0040
+Revises: 0003, 0020, 0030
+Create Date: 2026-04-22
+
+No-op merge migration collapsing three parallel branches (session
+last_active, subscription trial constraint, TOTP secrets) into a single
+head so `alembic upgrade head` (singular) succeeds without the
+`heads`/`head` workaround.
+"""
+
+from collections.abc import Sequence
+
+revision: str = "0040"
+down_revision: tuple[str, ...] = ("0003", "0020", "0030")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/MIGRATION_RANGES.md
+++ b/alembic/versions/MIGRATION_RANGES.md
@@ -9,6 +9,7 @@ each Phase 3 issue has a reserved range:
 | 0010–0019 | US #8  | Email verification    |
 | 0020–0029 | US #9  | Subscriptions         |
 | 0030–0039 | US #10 | 2FA / TOTP            |
+| 0040      | US #63 | Merge multi-heads     |
 
 Name your migration files with the appropriate prefix, e.g.:
 `0010_add_verification_tokens.py` for US #8.


### PR DESCRIPTION
## Summary

Closes #63.

Adds a no-op merge migration `0040_merge_multi_heads.py` whose `down_revision` is the tuple `("0003", "0020", "0030")`. This collapses the three parallel heads (session last_active, subscription trial constraint, TOTP secrets) into a single head so `alembic upgrade head` (singular) succeeds.

## Before / after

```
$ alembic heads       # before
0003 (head)
0020 (head)
0030 (head)

$ alembic heads       # after
0040 (head)
```

`alembic history` after:
```
0003, 0020, 0030 -> 0040 (head) (mergepoint), Merge multi-heads to single head.
0001 -> 0003, Add last_active column to sessions table.
0001 -> 0020, Add partial unique index to prevent concurrent active trials.
0010 -> 0030, Add totp_secrets table for 2FA support.
0001 -> 0010, Add indexes to verification_tokens for rate limiting and user lookups.
<base> -> 0001 (branchpoint), Initial schema — ...
```

Offline SQL dry-run (`alembic upgrade head --sql`) confirms the merge step collapses three rows in `alembic_version` into a single `0040`:
```
-- Running upgrade 0003, 0020, 0030 -> 0040
DELETE FROM alembic_version WHERE alembic_version.version_num = '0003';
DELETE FROM alembic_version WHERE alembic_version.version_num = '0020';
UPDATE alembic_version SET version_num='0040' WHERE alembic_version.version_num = '0030';
```

## Why `0040`

Keeps monotonic prefix convention with `MIGRATION_RANGES.md`. Reserved the single slot `0040` for this issue in the same doc.

## Acceptance criteria

- [x] `alembic heads` reports exactly one head
- [x] `alembic upgrade head` succeeds (dry-run SQL verified)
- [ ] deploy integration-test workaround `heads`→`head` reverted — **follow-up PR** after merge (tracked)
- [ ] Optional CI guard `alembic heads | wc -l` — defer (out of scope for urgent unblock)

## Unblocks

- noorinalabs/noorinalabs-deploy#85 (Lucas Ferreira — stg-first pre-deploy alembic gate) — was blocked on single-head state
- follow-up: revert `heads`→`head` in `noorinalabs-deploy` integration tests

## Reviewers

Requestor/Requestee/RequestOrReplied: Anya.Kowalczyk / Mateo.Salazar / Request — primary user-service review
Requestor/Requestee/RequestOrReplied: Anya.Kowalczyk / Aisha.Idrissi / Request — deploy-side cross-review (consumer of single-head state for #85)

## Contract

N/A — single-repo DB migration, not a Cross-Contract change.