### PR TITLE
ci(ghcr): emit sha-<short> + stg-<short> + stg-latest for same-SHA promotion (#64)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -4,6 +4,12 @@
 # and manual dispatch.
 # Builds multi-arch (amd64 + arm64) images for the user service
 # and pushes to ghcr.io/noorinalabs/noorinalabs-user-service.
+#
+# Notify-deploy is folded into this workflow as a dependent job so deploy
+# only fires after the image is published successfully. Replica of the
+# isnad-graph#815 Contract v6 pattern landed in noorinalabs-isnad-graph
+# commit b8931847 (2026-04-23). Tag emit shape is intentionally identical —
+# see the `Extract metadata` step comment block for the Contract table.
 
 name: Publish to GHCR
 
@@ -52,13 +58,33 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tag scheme (isnad-graph#815 Contract v6 = option C, 2026-04-23):
+          #   sha-<short>   — immutable, one per push; written here on every event
+          #   latest        — mutable pointer; written here on main + semver tags
+          #   stg-<short>   — immutable per-push, stg namespace; written here ONLY
+          #                   on push to main. Tag history = stg deploy log.
+          #   stg-latest    — moving pointer to most-recent stg-<short>; written
+          #                   here ONLY on push to main. Consumers pull this for
+          #                   a stable target without chasing SHAs.
+          #   prod-<short>  — immutable per-promotion, prod namespace; written by
+          #                   deploy#84 ONLY, NOT this file. Tag history = promotion log.
+          #   prod-latest   — moving pointer; written by deploy#84 ONLY.
+          # deploy#84 writes both prod-* tags in one `docker buildx imagetools
+          # create` invocation — registry-side manifest rewrite, no rebuild.
+          #
+          # Per-spec replica of noorinalabs-isnad-graph commit b8931847 (Linh Pham).
+          # Canonical Contract: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921
           tags: |
             # Git tag (e.g., v1.2.3 or phase12-wave1)
             type=ref,event=tag
-            # Short SHA (e.g., sha-a1b2c3d)
+            # Short SHA (e.g., sha-a1b2c3d) on every event — IMMUTABLE anchor
             type=sha,prefix=sha-,format=short
-            # Latest on main branch push or semver tags
+            # Latest on main-branch push or semver tags
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+            # stg-<short> per-push in stg namespace — IMMUTABLE, push-to-main only
+            type=sha,prefix=stg-,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            # stg-latest moving pointer — push-to-main only
+            type=raw,value=stg-latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         id: build
@@ -75,11 +101,11 @@ jobs:
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          # Scan by digest — guaranteed to exist immediately after `Build and push`
-          # and not subject to tag-resolution races. Previously used
-          # `:${{ github.ref_name }}` which on a `main` push resolves to `:main`,
-          # but the metadata-action emits only `:latest` and `:sha-XXXX` for
-          # main pushes — so the scan always 404'd with MANIFEST_UNKNOWN.
+          # Scan by digest — guaranteed to exist immediately after push and
+          # immune to tag-resolution races. metadata-action emits :latest,
+          # :sha-*, and (on main) :stg-* + :stg-latest — never :main.
+          # Digest is the one stable handle across all of them. See
+          # user-service#61 retro.
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: "1"
@@ -95,3 +121,28 @@ jobs:
           echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Platforms:** linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
           echo "- **SHA:** ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Digest:** ${{ steps.build.outputs.digest }}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Fire repository_dispatch to noorinalabs-deploy AFTER the image is published.
+  # Gated to main-branch pushes only — tag pushes and manual dispatches do NOT
+  # auto-deploy. The deploy workflow (deploy#84) consumes the SHA from this
+  # payload to deploy the exact same image to stg that was just built.
+  notify-deploy:
+    name: Notify deploy repo
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Trigger deploy repo
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_PAT }}
+          repository: noorinalabs/noorinalabs-deploy
+          event-type: deploy-noorinalabs-user-service
+          client-payload: >-
+            {
+              "repo": "noorinalabs-user-service",
+              "sha": "${{ github.sha }}",
+              "ref": "${{ github.ref_name }}",
+              "actor": "${{ github.actor }}"
+            }


### PR DESCRIPTION
## Summary

Updates `.github/workflows/ghcr-publish.yml` to emit the P2W10 image-tag Contract v6 tag set so this service's CI produces the exact set of tags that the staging/prod promotion pathway (deploy#84 / deploy#155) expects. Per-spec replica of `noorinalabs-isnad-graph` commit [`b8931847`](https://github.com/noorinalabs/noorinalabs-isnad-graph/commit/b8931847) (Linh Pham).

Closes #64.

## Contract (v6 = option C)

Canonical body: https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/815#issuecomment-4301538921

Tags emitted on push-to-main, all pointing at the same built digest (single build, multiple tag aliases via `docker/metadata-action`):

| Tag | Mutability | When | Where written |
|---|---|---|---|
| `sha-<short>` | immutable | every event | this workflow (existing) |
| `latest` | mutable | main + semver | this workflow (existing) |
| `stg-<short>` | **immutable** | push-to-main only | this workflow (**NEW**) |
| `stg-latest` | moving pointer | push-to-main only | this workflow (**NEW**) |
| `prod-<short>` | immutable | promotion | deploy#84 only (NOT here) |
| `prod-latest` | moving pointer | promotion | deploy#84 only (NOT here) |

Rationale for option C (stg-`<short>` + moving pointer, not bare `:stg`):
- stg tag history becomes the stg deploy log (`gh api ... /tags | grep stg-`)
- parallel shape for stg/prod enables `deploy#84` to mirror with `prod-<short>` + `prod-latest` via `docker buildx imagetools create` — registry-side manifest rewrite, no rebuild
- consumers pull `stg-latest` for a stable target without chasing SHAs

## Shape parity with isnad-graph b8931847

- ✅ Same four tag-emit rules with identical `enable:` predicates
- ✅ Trivy scan still by digest (unchanged; user-service#61 retro)
- ✅ Comment block references the canonical Contract URL and the source commit
- ✅ `notify-deploy` job folded in as `needs: build-and-push`, gated to `push` + `refs/heads/main`
- ✅ `repository_dispatch` payload carries `repo`, `sha`, `ref`, `actor` (event-type `deploy-noorinalabs-user-service`)

Only intentional divergences from isnad-graph (repo-shape, not Contract-shape):
- No multi-image matrix — user-service is a single image (`noorinalabs-user-service`)
- No design-system tarball staging — user-service has no frontend
- `event-type: deploy-noorinalabs-user-service` — per-service dispatch event so deploy#84 can route

## Out of scope (do NOT expect in this PR)

- `prod-<short>` / `prod-latest` emission — that's deploy#84 / merged deploy#155's job
- Deploy workflow itself (lives in `noorinalabs-deploy`)
- GHCR auth changes
- Rebuilds for prod (explicitly not done — same image promoted, not rebuilt)

## Test plan

- [ ] CI (this PR's `Publish to GHCR` run) emits `sha-<short>` + `latest` on PR push — stg tags correctly gated off (not main)
- [ ] After merge to main: `gh api /orgs/noorinalabs/packages/container/noorinalabs-user-service/versions --jq '.[0].metadata.container.tags'` shows `sha-<short>`, `latest`, `stg-<short>`, `stg-latest` all resolving to the same digest
- [ ] `repository_dispatch` event `deploy-noorinalabs-user-service` fires in noorinalabs-deploy with the SHA payload (deploy#84 consumer verification)
- [ ] Manual verification acceptance from #64: retagging `:sha-abc123` as `:prod-v1` works without a rebuild (`docker buildx imagetools create`)

## Constraints honored

- Contract NOT renegotiated — bug reports against v6 go to follow-up issues, not this PR (memory: `project_w10_image_tag_contract.md`)
- Minimal diff, shape matched exactly to keep the replica faithful
- Per-commit `-c` identity (no `git config`)

Refs: noorinalabs/noorinalabs-main#141 (W10 meta)
