### PR TITLE
chore(hooks): scaffold .claude/settings.json with Hook 14 (#194, closes #215 partial)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,66 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_commit_identity.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_no_verify.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_git_config.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_set_env_test.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_labels.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_ci_status.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Scaffolds `.claude/settings.json` for the **first time** in this repo, registering the standard 5 PreToolUse Bash hooks shared across the org PLUS `validate_pr_ci_status` (Hook 14).

This is the **sixth fan-out PR** for Hook 14 sync (parent issue: noorinalabs/noorinalabs-main#194) AND closes the user-service half of noorinalabs/noorinalabs-main#215 (bare-settings audit — this repo had hook .py files but no settings.json wiring them up; every PreToolUse gate was silently inactive).

## Why this is a scaffold, not a 1-line change

Survey during #194 execution found this repo lacks `.claude/settings.json` entirely (per #215). The hook .py files in `.claude/hooks/` (validate_commit_identity, block_no_verify, block_git_config, block_gh_pr_review, annunaki_log) are **dead weight without a settings.json to wire them up**. So this PR has to scaffold the full settings.json from scratch, not just append a Hook 14 entry.

## Pattern choice — symlink-style (parent-canonical paths)

Per program-director steer 2026-04-28: **lighter-touch symlink approach** matching the steady-state direction of #214 cleanup. Settings.json registers all 6 hooks via parent-canonical absolute paths — no copy-resident pattern, no churn against the existing local .py copies. The local copies become inert under this config and will be cleaned during #214 rationalization. Their continued presence does not affect runtime.

## Hooks registered (all 6)

1. `validate_commit_identity.py` — commit identity per-commit `-c` flag enforcement
2. `block_no_verify.py` — prevents bypass of pre-commit hooks
3. `block_git_config.py` — prevents git-config write commands
4. `auto_set_env_test.py` — auto-injects ENVIRONMENT=test for pytest invocations
5. `validate_labels.py` — label hygiene before `gh issue create`
6. `validate_pr_ci_status.py` — **Hook 14, the new addition** — gates `gh pr merge` on green CI

All 6 paths are `python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/<name>.py` — single source of truth at the parent.

## Verification

- `python3 -c "import json; json.load(open('.claude/settings.json'))"` — well-formed
- 6 Bash matcher entries (was 0 before this PR)

## Test plan

- [ ] Reviewer 1 inspects the 66-line settings.json — entries match the symlink-style children (landing-page#72, data-acquisition#32, design-system#61) plus Hook 14
- [ ] Reviewer 2 confirms parent-canonical paths exist at the listed locations
- [ ] After merge: `gh pr merge` against a future user-service PR with a deliberately failing check should block (Hook 14 self-test)
- [ ] After merge: `git commit` without `-c` flags should be blocked by validate_commit_identity (gate parity restored — was silently inactive before)

## Refs

- Parent issue: noorinalabs/noorinalabs-main#194 (Hook 14 sync)
- Parent issue: noorinalabs/noorinalabs-main#215 (bare-settings audit — closes user-service half)
- Followup noorinalabs/noorinalabs-main#214 (rationalization to single hook-registration pattern, p2-wave-11)
- Sibling fan-out PRs (merged): landing-page#72, data-acquisition#32, design-system#61
- Sibling fan-out PRs (open): noorinalabs-isnad-graph#845, noorinalabs-deploy#186
- Charter: `noorinalabs-main/.claude/team/charter/hooks.md` § Hook 14
