### PR TITLE
tech-debt(alembic): restore default script.py.mako template (closes #82)

### DIFF
--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}


### PR DESCRIPTION
## Summary

Adds the missing Alembic-default `script.py.mako` revision template to `alembic/script.py.mako`. Without it, CLI revision-generation commands (`alembic revision -m "..."`, `alembic revision --merge`, `alembic revision --autogenerate`) fall back silently to the library-bundled template instead of using a repo-controlled one.

The template content was generated by `alembic init` against the currently pinned `alembic>=1.14.0`, so the file matches the canonical default for the version this repo is on.

## Why now

Flagged by Anya Kowalczyk during user-service#63 (alembic merge migration). She had to hand-author `0040_merge_multi_heads.py` because `alembic revision --merge` couldn't run without this template. The merge migration itself was correct; this PR closes the underlying environment gap she surfaced.

## Validation

In the worktree, after dropping the template in:

```
$ uv run alembic revision -m "test_template_smoke"
Generating .../alembic/versions/d3a3fd1ca71a_test_template_smoke.py ...  done
```

The generated file had the expected shape:
- correct revision-id pattern (`d3a3fd1ca71a`)
- correct `down_revision = '0040'` (parent = the merge migration)
- valid `upgrade()` / `downgrade()` stubs returning `pass`
- proper `Sequence`/`Union` typing matching alembic 1.14+ defaults

Test revision was deleted; only `alembic/script.py.mako` ships in this PR.

`make lint` is clean. (`make typecheck` reports 2 pre-existing `unused-ignore` errors in `src/app/services/token.py:43,57` introduced in `4bda85a` — unrelated to this change.)

## Scope

- Single file added: `alembic/script.py.mako`
- `env.py`, `alembic.ini`, and existing migrations are untouched

Closes #82
