### PR TITLE
fix(ci): trigger GHCR Publish on pull_request for pre-merge Trivy validation (closes #61)

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -92,16 +92,25 @@ jobs:
 
       - name: Resolve Trivy image reference
         id: scan_ref
+        env:
+          # Bind GHA expressions to env vars so the shell sees stable
+          # variables rather than text-substituted values — closes the
+          # script-injection sink Idris flagged on PR #87 review (Q2).
+          # Same env-var idiom used in the `Summary` step below.
+          EVENT_NAME: ${{ github.event_name }}
+          META_TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE_FQN: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # PR: image is loaded locally (push: false). Reference the first
             # tag the metadata-action emitted (the sha-<short> tag, which is
             # always present per the tags: config above).
-            FIRST_TAG=$(printf '%s' '${{ steps.meta.outputs.tags }}' | head -n1)
-            echo "ref=${FIRST_TAG}" >> "$GITHUB_OUTPUT"
+            FIRST_TAG=$(printf '%s' "$META_TAGS" | head -n1)
+            echo "ref=$FIRST_TAG" >> "$GITHUB_OUTPUT"
           else
             # Push/tag: scan by registry digest — race-free post-push (W8 #111).
-            echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+            echo "ref=${IMAGE_FQN}@${BUILD_DIGEST}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Trivy vulnerability scan

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,9 +1,10 @@
 # Publish container images to GitHub Container Registry (GHCR).
 #
-# Triggers: tag push matching v* or phase*-wave* patterns, main branch push,
-# and manual dispatch.
-# Builds multi-arch (amd64 + arm64) images for the user service
-# and pushes to ghcr.io/noorinalabs/noorinalabs-user-service.
+# Triggers: tag push (v* or phase*-wave*), main branch push, manual dispatch,
+# and pull_request when the workflow / Dockerfile / src/** change.
+# Push events build multi-arch (amd64 + arm64) and push to GHCR.
+# pull_request events build single-arch (amd64) for Trivy scanning only —
+# no push, so PR-builder images are never published to the registry.
 
 name: Publish to GHCR
 
@@ -13,11 +14,18 @@ on:
     tags:
       - "v*"
       - "phase*-wave*"
+  pull_request:
+    paths:
+      - .github/workflows/ghcr-publish.yml
+      - Dockerfile
+      - "src/**"
   workflow_dispatch:
 
 concurrency:
-  group: publish-${{ github.ref_name }}
-  cancel-in-progress: false
+  # event_name in the group key prevents PR runs from cancelling main pushes;
+  # cancel-in-progress is enabled only for PRs so a force-push supersedes its scan.
+  group: publish-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -41,6 +49,10 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Log in to GHCR
+        # Skipped on pull_request — PR runs do not push, so no registry creds
+        # are exposed to PR-context jobs (which run with read-only GITHUB_TOKEN
+        # for forks anyway, but keeping the step gated is defence-in-depth).
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -55,9 +67,11 @@ jobs:
           tags: |
             # Git tag (e.g., v1.2.3 or phase12-wave1)
             type=ref,event=tag
-            # Short SHA (e.g., sha-a1b2c3d)
+            # Short SHA (e.g., sha-a1b2c3d) — also emitted on PR for the
+            # local image ref Trivy scans.
             type=sha,prefix=sha-,format=short
-            # Latest on main branch push or semver tags
+            # Latest only on main branch push or semver tags. The enable
+            # expression already excludes pull_request (refs/pull/N/merge).
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
@@ -65,22 +79,36 @@ jobs:
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
+          # PRs build single-arch (amd64) and load into the local Docker daemon
+          # so Trivy can scan by tag without pushing. Push events build the
+          # full multi-arch matrix and push to the registry.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Resolve Trivy image reference
+        id: scan_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR: image is loaded locally (push: false). Reference the first
+            # tag the metadata-action emitted (the sha-<short> tag, which is
+            # always present per the tags: config above).
+            FIRST_TAG=$(printf '%s' '${{ steps.meta.outputs.tags }}' | head -n1)
+            echo "ref=${FIRST_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            # Push/tag: scan by registry digest — race-free post-push (W8 #111).
+            echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          # Scan by digest — guaranteed to exist immediately after `Build and push`
-          # and not subject to tag-resolution races. Previously used
-          # `:${{ github.ref_name }}` which on a `main` push resolves to `:main`,
-          # but the metadata-action emits only `:latest` and `:sha-XXXX` for
-          # main pushes — so the scan always 404'd with MANIFEST_UNKNOWN.
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          # Both paths block on CRITICAL/HIGH so PR Trivy failures gate the merge.
+          image-ref: ${{ steps.scan_ref.outputs.ref }}
           format: table
           exit-code: "1"
           severity: CRITICAL,HIGH
@@ -88,10 +116,25 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          IMAGE_FQN: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          GIT_SHA: ${{ github.sha }}
         run: |
-          echo "## GHCR Publish: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Tag:** ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Image:** ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Platforms:** linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **SHA:** ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            MODE="scan-only (PR — no push)"
+            PLATFORMS="linux/amd64"
+          else
+            MODE="build + push"
+            PLATFORMS="linux/amd64, linux/arm64"
+          fi
+          {
+            echo "## GHCR Publish: ${{ job.status }}"
+            echo ""
+            echo "- **Mode:** $MODE"
+            echo "- **Ref:** $REF_NAME"
+            echo "- **Image:** $IMAGE_FQN"
+            echo "- **Platforms:** $PLATFORMS"
+            echo "- **SHA:** $GIT_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Closes #61.

The `Publish to GHCR` workflow previously triggered only on push to `main`, tag pushes, and manual dispatch — so any change to the workflow itself (or to anything Trivy scans) landed unverified, with the next push to main being the actual validation moment. W8 #111 (the original Trivy `MANIFEST_UNKNOWN` fix) demonstrated the gap.

This PR adds a `pull_request` trigger with a `paths:` filter scoped to the workflow file, `Dockerfile`, and `src/**`. Trivy still runs on PR; the actual `docker push` is suppressed.

### Trigger + push-skip semantics

| Aspect | `push` / tag (unchanged) | `pull_request` (new) |
|---|---|---|
| GHCR login | yes | **skipped** (no registry creds in PR-context jobs) |
| Platforms | `linux/amd64,linux/arm64` | `linux/amd64` (buildx requires single-arch with `load: true`) |
| `push:` | `true` | `false` |
| `load:` | `false` | `true` (image into local Docker daemon for Trivy) |
| `latest` tag | emitted on `refs/heads/main` and `refs/tags/v*` | **not emitted** (the existing enable expression already excludes `refs/pull/*`) |
| Trivy `image-ref` | registry digest (race-free, W8 #111) | locally-loaded `sha-<short>` tag |
| Trivy gating | CRITICAL/HIGH → step fails | CRITICAL/HIGH → step fails (blocks PR) |

### Concurrency

The previous group `publish-${{ github.ref_name }}` would have collided across event types. New group is `publish-${{ github.event_name }}-${{ github.ref_name }}`, with `cancel-in-progress` enabled only for PRs (so a force-push supersedes its scan, but a PR run can never cancel a `main` push run mid-flight).

### Verification

- `actionlint v1.7.7` (with `shellcheck v0.10.0` on PATH per memory `feedback_actionlint_needs_shellcheck.md`): **exit 0, no findings** on the modified workflow.
- Diff: `1 file changed, 65 insertions(+), 22 deletions(-)`.
- See `git log -p` of the YAML diff in this PR for the full delta.

### Test plan

PR-acceptance items (verifiable on this PR):

- [x] `actionlint` clean
- [x] Workflow YAML lints; expression syntax for conditional `push`/`load`/`platforms` is valid GHA
- [x] `pull_request` trigger fires on this PR (the workflow modification matches the `paths:` filter — this PR is its own first triggering artifact)
- [x] Trivy step still has `exit-code: "1"` and `severity: CRITICAL,HIGH` — PR scans gate merge

Post-merge / runtime-gate items (per memory `feedback_runtime_gate_scoping.md` and `feedback_pr_vs_runtime_acceptance_criteria.md` — operational events at later lifecycle, not PR blockers):

- [ ] Observe a follow-up PR that touches `Dockerfile` or `src/**` triggering this workflow on PR (no push to GHCR observed)
- [ ] Confirm next `main` push still produces a multi-arch image with the four-tag set per Image-tag Contract v6
- [ ] Confirm `repository_dispatch` deploy notification (handled in `notify_deploy` workstream — out of scope here) still fires on push only

### Reviewers

- @Anya-Kowalczyk (Tech Lead) — workflow architecture / event-name conditionals correctness
- @Idris-Yusuf (Security Engineer) — Trivy scan posture on PR (untrusted-fork creds, image-ref correctness, no PR image leak to GHCR)
