### PR TITLE
fix(ci): trigger ci.yml on deployments/** branches (closes #81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "deployments/**"
 
 jobs:
   check:


### PR DESCRIPTION
Closes #81

## Summary

Adds `deployments/**` to `ci.yml`'s `on.pull_request.branches` filter so PRs targeting long-lived wave branches (e.g., `deployments/phase-2/wave-10`) exercise the same `ruff check`, `ruff format --check`, and `pytest` jobs main-targeted PRs do.

## Diff

```yaml
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "deployments/**"
```

3 insertions, 1 deletion. Trigger expansion only — no change to job definitions or paths filtering. ghcr-publish.yml is unaffected (uses a `paths:` filter without a `branches:` filter, so it already fires on PRs to any branch).

## Sibling-of-main#194

Same anti-pattern: a gate that exists but doesn't fire on the relevant code path. main#194 was Hook 14 not synced into child repos before its fan-out; this is `ci.yml` not configured for the wave-branch PR target shape W10 introduced. Both classes share root cause "infrastructure exists, isn't wired to the actual workflow". Per memory `feedback_enforcement_hierarchy.md`: prefer hook > skill > charter. Manual attestation in PR bodies is the weakest tier.

## Live-trace evidence

**Pre-fix observation** — user-service PR#80 (Anya Kowalczyk, closes #63, 2026-04-23) targeted `deployments/phase-2/wave-10`. `gh pr view 80 --json statusCheckRollup` returned an empty array because `ci.yml`'s `branches: [main]` filter excluded the wave-branch target. Anya ran `ruff check`, `ruff format --check`, `mypy`, and pytest locally and attested in the PR body — the W10 spawn-prompt's documented "Hook 14 not synced, manual verification" fallback. With this fix, future wave-targeted PRs trigger the workflow automatically.

## actionlint

```
$ actionlint .github/workflows/ci.yml
$ echo $?
0
```

shellcheck on PATH (per memory `feedback_actionlint_needs_shellcheck.md`).

## Sibling-workflow audit

`ghcr-publish.yml` was reviewed at HEAD-of-main (commit `88a1cc7` — my own #87 merge):
- `pull_request.paths:` filter present, `branches:` filter absent
- Per GitHub docs, omitting `branches:` matches all branches, so it already fires on PRs to any branch (subject to the path filter)
- No fix required, no follow-up issue filed

## Test plan

This change is hard to verify pre-merge: the new `deployments/**` glob only fires on a PR that targets a deployments branch, and merging this PR is what enables that. Per memory `feedback_pr_vs_runtime_acceptance_criteria.md`, recording the runtime-verification step as a post-merge item:

- [ ] **Post-merge:** the next user-service PR targeting `deployments/phase-2/wave-N` should populate `statusCheckRollup` non-empty (ruff/format/pytest jobs visible). Verify via `gh pr view <next-wave-pr> --json statusCheckRollup,state,mergedAt --jq '.statusCheckRollup'`.
- [ ] **Live-trace baseline:** the PR#80 empty-rollup observation cited above is the pre-fix anchor. The first non-empty rollup on a `deployments/**`-targeted PR after merge confirms the gate fires.

PR review acceptance is unit-mechanic correctness of the trigger expansion (covered by actionlint exit 0 + the sibling-workflow audit above).

## Reviewers

- @anya-kowalczyk (Tech Lead) — primary
- @idris-yusuf (Security Engineer) — secondary; aware Idris may be busy from earlier W10 work, requesting per charter 2-reviewer rule

(Reviewer requests via PR comment, not `gh pr review`, per memory `feedback_pr_review_comment_only.md`.)
