### PR TITLE
security(docs): disable FastAPI docs + OpenAPI spec in production (#91)

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from src.app.config import Settings, get_settings
 from src.app.database import close_db, close_redis, init_db, init_redis
 from src.app.middleware.cors import add_cors_middleware
 from src.app.middleware.security import add_security_headers
@@ -28,11 +29,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await close_db()
 
 
-def create_app() -> FastAPI:
+def create_app(settings: Settings | None = None) -> FastAPI:
+    if settings is None:
+        settings = get_settings()
+
+    # Disable interactive docs and the OpenAPI spec in production only.
+    # Staging keeps them enabled for QA against testing-mode OAuth allowlist
+    # users (deploy#244 runbook); local dev inherits the staging shape.
+    is_prod = settings.ENVIRONMENT == "production"
     application = FastAPI(
         title="NoorinALabs User Service",
         version="0.1.0",
         lifespan=lifespan,
+        docs_url=None if is_prod else "/docs",
+        redoc_url=None if is_prod else "/redoc",
+        openapi_url=None if is_prod else "/openapi.json",
     )
 
     add_cors_middleware(application)

--- a/tests/test_docs_gated.py
+++ b/tests/test_docs_gated.py
@@ -42,9 +42,7 @@ async def test_production_returns_404(path: str) -> None:
 async def test_non_production_returns_200(environment: str, path: str) -> None:
     async for client in _client_for(environment):
         response = await client.get(path)
-        assert response.status_code == 200, (
-            f"{path} should be 200 in ENVIRONMENT={environment}"
-        )
+        assert response.status_code == 200, f"{path} should be 200 in ENVIRONMENT={environment}"
 
 
 async def test_default_environment_serves_docs() -> None:

--- a/tests/test_docs_gated.py
+++ b/tests/test_docs_gated.py
@@ -1,0 +1,58 @@
+"""Tests for env-keyed disable of FastAPI docs endpoints.
+
+In production, /docs, /redoc, and /openapi.json must return 404. In all other
+environments (staging, test, development) they must return 200. The OpenAPI
+JSON spec is the underlying leak — Swagger UI just renders it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.app.config import Settings
+from src.app.main import create_app
+
+
+def _make_settings(environment: str) -> Settings:
+    return Settings(ENVIRONMENT=environment)  # type: ignore[call-arg]
+
+
+async def _client_for(environment: str) -> AsyncGenerator[AsyncClient, None]:
+    app = create_app(settings=_make_settings(environment))
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+async def test_production_returns_404(path: str) -> None:
+    async for client in _client_for("production"):
+        response = await client.get(path)
+        assert response.status_code == 404, f"{path} should be 404 in production"
+
+
+@pytest.mark.parametrize(
+    "environment",
+    ["staging", "test", "development"],
+)
+@pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+async def test_non_production_returns_200(environment: str, path: str) -> None:
+    async for client in _client_for(environment):
+        response = await client.get(path)
+        assert response.status_code == 200, (
+            f"{path} should be 200 in ENVIRONMENT={environment}"
+        )
+
+
+async def test_default_environment_serves_docs() -> None:
+    """Verify the no-arg create_app() path (which uses get_settings()) still serves
+    docs in the default development environment — guards against accidentally
+    locking docs out of local dev."""
+    app = create_app()
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/openapi.json")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

Disables interactive FastAPI docs (`/docs`, `/redoc`) and the underlying OpenAPI spec (`/openapi.json`) in production. Staging, test, and local development environments keep them enabled.

Bereket-review caught during P3W3 review of `noorinalabs-deploy#266` that `https://users.noorinalabs.com/docs` returns HTTP 200 with a fully rendered Swagger UI, and the OpenAPI spec at `/openapi.json` is anonymously fetchable. For an auth/sessions/2FA service the spec leak is the bigger threat — Swagger is just a renderer over it.

## Decision: prod-disable / stg-enable

| Environment | `docs_url` | `redoc_url` | `openapi_url` | Rationale |
|---|---|---|---|---|
| `production` | `None` (404) | `None` (404) | `None` (404) | Anonymous spec leak closed; aligns with read-only filesystem container security posture |
| `staging` | `/docs` (200) | `/redoc` (200) | `/openapi.json` (200) | Internal-test-users-allowlisted per `deploy#244` OAuth Testing-mode runbook — QA value of interactive docs preserved |
| `test` | enabled | enabled | enabled | CI/local pytest fixtures need the spec |
| `development` | enabled | enabled | enabled | Inherits the staging shape for local dev parity |

Owner picked Option A (security-posture-converge) over the Caddyfile carve-out and ship-as-is alternatives during the deploy#266 review thread.

## Implementation

`create_app()` in `src/app/main.py` now accepts an optional `Settings` parameter. When omitted (the module-level `app = create_app()` import-time path) it falls back to `get_settings()`. Inside, `is_prod = settings.ENVIRONMENT == "production"` keys the three `FastAPI(...)` URL kwargs.

The Settings-injection seam exists specifically so tests can exercise each environment without mutating the `@lru_cache` on `get_settings()`. Production code path is unchanged.

## Tests

13 new tests in `tests/test_docs_gated.py`:
- `production` returns 404 for `/docs`, `/redoc`, `/openapi.json`
- `staging`, `test`, `development` each return 200 for all three paths
- Default `create_app()` (no settings arg, runs under `ENVIRONMENT=test` per the test harness) still serves `/openapi.json` — guards against accidentally locking docs out of local dev

## Sequencing

This PR is the merge prerequisite for `noorinalabs-deploy#266` (Lucas-243's strict CSP). Once this lands, Bereket-review's ChangesRequested on #266 flips to Approved.

## Test plan

- [x] `make test` passes 247/247 in worktree (including 13 new docs-gating tests)
- [x] `make lint` clean
- [x] `make typecheck` — pre-existing token.py mypy errors only, unrelated to this diff
- [ ] Post-merge runtime live-trace: `curl -i https://users.noorinalabs.com/docs` returns 404 (per `feedback_runtime_gate_scoping.md`, runtime verification is post-merge — PR-level acceptance is the test-harness)
- [ ] Post-merge: `noorinalabs-deploy#266` re-review → flip to Approved → CSP merge

TechDebt: <none>

Requestor: Idris Yusuf
Requestee: Anya Kowalczyk
RequestOrReplied: Request

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
