### PR TITLE
docs(CLAUDE.md): branching strategy backslash → slash (closes #90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,4 +123,4 @@ Copy `.env.example` to `.env`. Key variables:
 - **GitHub Issues** — story/task/bug tracking (created by Manager, assigned to team members)
 - **GitHub Actions** — CI/CD pipelines, automated tests, linting, deployment
 - These three (Projects, Issues, Actions) are the **core orchestration layer** — do not introduce alternative tools for these concerns
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `M.Salazar\0003-claude-md-charter-roster`) merged to `main` via PR
+- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `M.Salazar/0003-claude-md-charter-roster`) merged to `main` via PR


### PR DESCRIPTION
## Summary

Single-line CLAUDE.md fix: branching-strategy template and example used a literal backslash that git rejects in refnames. Replaces `\` with `/` so the doc matches actual repo convention (and parent CLAUDE.md L67).

```diff
-- **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}\{IIII}-{issue-name}` (e.g., `M.Salazar\0003-claude-md-charter-roster`) merged to `main` via PR
++ **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `M.Salazar/0003-claude-md-charter-roster`) merged to `main` via PR
```

Two occurrences on the line: template and example. Both fixed.

## Why this matters

Spawned implementers reading CLAUDE.md verbatim hit `git: 'X.Y\NNNN-...' is not a valid branch name` and have to fall back to repo convention. Two independent confirmations in P3W1 Round 1 (deploy-aisha #179, deploy-lucas #67).

## Linkage

- Closes #90
- Parent meta-issue: noorinalabs/noorinalabs-main#232 (parent CLAUDE.md fix already landed on `deployments/phase-3/wave-1`)
- Pattern parallel to W10 Hook 14 fan-out (noorinalabs-main#194)

## Wave-bootstrap class — single-reviewer exception

Per parent charter § Single-Reviewer Exception, owner-approved at W4 kickoff and logged in `cross-repo-status.json` `wave_4_decisions.single_reviewer_exception`. `wave-bootstrap` label applied.

## Test plan

- [ ] CI green
- [ ] grep verifies single occurrence on L126 uses `/` in both template and example
- [ ] Reviewer (Anya) confirms branching-strategy line matches parent CLAUDE.md L67 canonical form

## Base

`deployments/phase-3/wave-4` — wave-4 bootstrap PR.
