### PR TITLE
ci: upgrade actions/checkout@v4 → v6 (closes #101, parent#309)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev
       - run: uv run ruff check .

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU (multi-arch)
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0


### PR DESCRIPTION
## Summary

Upgrades `actions/checkout` from v4 (Node 20) to v6 (Node 24-compatible) in this repo's two workflows. Matches the [`noorinalabs-isnad-graph` reference state](https://github.com/noorinalabs/noorinalabs-isnad-graph) per the org-wide audit table in parent meta.

Closes #101
Refs noorinalabs/noorinalabs-main#309

## Changes

| File | Before | After | Style |
|------|--------|-------|-------|
| `.github/workflows/ci.yml` | `actions/checkout@v4` | `actions/checkout@v6` | floating major (matches isnad-graph `ci.yml`) |
| `.github/workflows/ghcr-publish.yml` | `actions/checkout@11bd7190... # v4.2.2` | `actions/checkout@de0fac2e... # v6.0.2` | full SHA pin (preserves Trivy-review hardening pattern) |

The `ghcr-publish.yml` workflow pins all third-party actions to full SHAs as a supply-chain hardening measure established in the original Trivy security review (#83 / #87). Preserving the SHA-pinned form there keeps that posture intact while bumping to the v6 generation.

## Verification of v6.0.2 SHA

```
$ gh api repos/actions/checkout/git/refs/tags | jq '.[] | select(.ref == "refs/tags/v6.0.2")'
{ "ref": "refs/tags/v6.0.2", "object": { "sha": "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "type": "commit" } }
```

## Acceptance

- [x] `actions/checkout@v4` upgraded to current Node 24-compatible major (v6) — both files
- [x] `actionlint` (with `shellcheck` on PATH) clean locally
- [ ] CI green post-upgrade with no Node 20 deprecation warning in either workflow run — verify on this PR's CI run
- [x] PR cross-links parent#309

## Test plan

- [ ] CI workflow (`ci.yml`) runs green on this PR
- [ ] `ghcr-publish.yml` PR-trigger path (build + Trivy scan) runs green on this PR — workflow is path-gated to `.github/workflows/**` / `Dockerfile` / `src/**`; this PR touches `.github/workflows/ghcr-publish.yml` so the path filter matches
- [ ] No `Node.js 20 actions are deprecated` warning in either workflow's logs

## Deadlines (from parent#309)

- Soft: 2026-06-02 (Node 24 forced default)
- Hard: 2026-09-16 (Node 20 removed from runners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
