### PR TITLE
fix: dispose engine on shutdown via explicit module-level reference (#51)

### DIFF
--- a/src/app/database.py
+++ b/src/app/database.py
@@ -3,20 +3,26 @@
 from collections.abc import AsyncGenerator
 
 from redis.asyncio import Redis
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from src.app.config import get_settings
 
+_engine: AsyncEngine | None = None
 _async_session_factory: async_sessionmaker[AsyncSession] | None = None
 _redis_client: Redis | None = None
 
 
 async def init_db() -> None:
     """Initialize the database engine and session factory."""
-    global _async_session_factory
+    global _engine, _async_session_factory
     settings = get_settings()
-    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
-    _async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    _engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    _async_session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 
 
 async def init_redis() -> None:
@@ -28,12 +34,10 @@ async def init_redis() -> None:
 
 async def close_db() -> None:
     """Dispose the engine and clear the session factory."""
-    global _async_session_factory
-    if _async_session_factory is not None:
-        # Get engine from the session factory bind
-        engine = _async_session_factory.kw.get("bind")
-        if engine is not None:
-            await engine.dispose()
+    global _engine, _async_session_factory
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
     _async_session_factory = None
 
 

--- a/tests/test_database_lifecycle.py
+++ b/tests/test_database_lifecycle.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.app import database
+from src.app.config import Settings
+
+
+@pytest.mark.asyncio
+async def test_close_db_disposes_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    test_settings = Settings(DATABASE_URL="sqlite+aiosqlite:///:memory:")  # type: ignore[call-arg]
+    monkeypatch.setattr(database, "get_settings", lambda: test_settings)
+
+    await database.init_db()
+    engine = database._engine
+    assert engine is not None
+    assert database._async_session_factory is not None
+
+    disposed = False
+    original_dispose = engine.sync_engine.dispose
+
+    def tracking_dispose(*args: object, **kwargs: object) -> None:
+        nonlocal disposed
+        disposed = True
+        original_dispose(*args, **kwargs)
+
+    monkeypatch.setattr(engine.sync_engine, "dispose", tracking_dispose)
+
+    await database.close_db()
+
+    assert disposed, "close_db() must dispose the engine"
+    assert database._engine is None
+    assert database._async_session_factory is None


### PR DESCRIPTION
## Summary

`close_db()` recovered the engine via `_async_session_factory.kw.get("bind")`. SQLAlchemy 2.0.49 *does* normalize the positionally-passed engine into `.kw["bind"]`, so the engine was actually being disposed on this version — but that normalization is an undocumented implementation detail and could silently break on a future SQLAlchemy bump, at which point `close_db()` would silently skip disposal and leak the connection pool.

This switches to an explicit `_engine` module-level reference set in `init_db()` and disposed directly in `close_db()` — disposal no longer depends on SQLAlchemy internals.

## Changes

- `src/app/database.py` — add `_engine: AsyncEngine | None` module global; `init_db` assigns it; `close_db` disposes it directly and clears both globals.
- `tests/test_database_lifecycle.py` — new test asserting `close_db()` disposes the engine (spies on `engine.sync_engine.dispose`) and clears `_engine` / `_async_session_factory`.

## Scope note

The issue body states `async_sessionmaker` does *not* store the engine in `.kw["bind"]`. Empirically on the pinned SQLAlchemy 2.0.49 it *does* (positional engine is normalized into `kw`), so the pre-fix code was not actually leaking on this version. The fix is still correct and worth landing: it removes the reliance on an undocumented internal and makes disposal robust across SQLAlchemy versions. Flagging the premise mismatch for the record — the fix shape and impact framing still hold.

## Test plan

- [x] `ENVIRONMENT=test pytest tests/test_database_lifecycle.py` — passes
- [x] Full suite: 248 passed (was 247 + 1 new)
- [x] `make lint` — clean
- [x] `make typecheck` — 2 pre-existing errors in `src/app/services/token.py` (unrelated, present on base branch `deployments/phase-3/wave-10`; not touched by this PR)

Closes #51
