### PR TITLE
techdebt(mypy): remove unused type-ignore comments in token.py (#76)

### DIFF
--- a/src/app/services/token.py
+++ b/src/app/services/token.py
@@ -40,9 +40,7 @@ def create_access_token(
         "type": "access",
     }
     private_key = get_private_key(settings)
-    token: str = jwt.encode(  # type: ignore[no-untyped-call]
-        payload, private_key, algorithm=settings.JWT_ALGORITHM
-    )
+    token: str = jwt.encode(payload, private_key, algorithm=settings.JWT_ALGORITHM)
     return token, expires_at
 
 
@@ -54,7 +52,7 @@ def create_refresh_token() -> str:
 def decode_access_token(settings: Settings, token: str) -> dict[str, Any]:
     """Decode and validate an access token. Raises JWTError on failure."""
     public_key = get_public_key(settings)
-    payload: dict[str, Any] = jwt.decode(  # type: ignore[no-untyped-call]
+    payload: dict[str, Any] = jwt.decode(
         token,
         public_key,
         algorithms=[settings.JWT_ALGORITHM],


### PR DESCRIPTION
## Summary

`make typecheck` reported two pre-existing errors on `deployments/phase-3/wave-10`:

```
src/app/services/token.py:43: error: Unused "type: ignore" comment  [unused-ignore]
src/app/services/token.py:57: error: Unused "type: ignore" comment  [unused-ignore]
```

The `jwt.encode` / `jwt.decode` calls carried `# type: ignore[no-untyped-call]` suppressions. The python-jose type stubs now type these calls, so the suppressions are redundant and mypy strict flags them. This unblocks the CI typecheck gate for **all** in-flight user-service PRs (#105, #107, #55, the incoming CVE bump).

## Changes

- `src/app/services/token.py` — removed the two now-unused `# type: ignore[no-untyped-call]` comments (the `jwt.encode` call collapses back to a single line).

## Verification

- Confirmed the ignores were genuinely unused: removing them surfaced **no** real suppressed error — `make typecheck` goes from 2 errors to `Success: no issues found in 44 source files`.
- `make lint` — clean.
- Full test suite — 247 passed.

Closes #76
