### PR TITLE
tech-debt(security): bump Mako + python-multipart — 2 HIGH CVEs (closes #109)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -550,14 +550,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -994,11 +994,11 @@ cryptography = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.24"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps two transitive Python dependencies to clear 2 HIGH CVEs flagged by Trivy in `ghcr-publish.yml`'s image scan.

| Library | CVE | Severity | Before | After | Fixed in |
|---------|-----|----------|--------|-------|----------|
| Mako | CVE-2026-44307 | HIGH | 1.3.10 | 1.3.12 | 1.3.12 |
| python-multipart | CVE-2026-42561 | HIGH | 0.0.24 | 0.0.28 | 0.0.27 |

- **CVE-2026-44307** — Mako path traversal via backslash URI on Windows in `TemplateLookup`.
- **CVE-2026-42561** — python-multipart Denial of Service via unbounded input.

`python-multipart` resolves to **0.0.28** (latest), which is newer than the 0.0.27 fix version — CVE still resolved.

## Changes

- `uv lock --upgrade-package mako --upgrade-package python-multipart` — `uv.lock` only, 6/6 lines, no unrelated dependency churn.
- Both are transitive (not direct deps in `pyproject.toml`) — via alembic / fastapi.

## Why wave-10

These CVEs surfaced while merging #105 (checkout@v6, Node-20 deprecation) — that PR re-triggered `ghcr-publish.yml` for the first time since the CVEs were disclosed (last green main run: 2026-05-06). They are **not** introduced by #105. Landing this re-greens `ghcr-publish.yml` so #105 can merge on a clean Trivy gate.

## Test plan

- [x] All 247 tests pass (`ENVIRONMENT=test make test`)
- [ ] `ghcr-publish.yml` Trivy scan green on this PR — no HIGH/CRITICAL
- [ ] CI `check` job green

> Note: a pre-existing `typecheck` failure on `token.py` (US#76, fixed in parallel by Mateo Salazar) may show red on this PR's `typecheck` job — unrelated to this lockfile change.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)