### PR TITLE
refactor(US#54): dedup _hash_token helper + add subscriptions.user_id index

### DIFF
--- a/alembic/versions/0041_add_subscriptions_user_id_index.py
+++ b/alembic/versions/0041_add_subscriptions_user_id_index.py
@@ -1,0 +1,33 @@
+"""Add index on subscriptions.user_id.
+
+The subscriptions table only had a partial unique index covering
+(user_id) WHERE plan='trial' AND status='active'. Equality lookups by
+user_id alone — get_current_subscription, get_subscription_status,
+start_trial, cancel_subscription — could not use it and fell back to a
+sequential scan. This adds a plain B-tree index on user_id.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-05-14
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0041"
+down_revision: str = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_subscriptions_user_id",
+        "subscriptions",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_subscriptions_user_id", table_name="subscriptions")

--- a/alembic/versions/MIGRATION_RANGES.md
+++ b/alembic/versions/MIGRATION_RANGES.md
@@ -10,6 +10,7 @@ each Phase 3 issue has a reserved range:
 | 0020–0029 | US #9  | Subscriptions         |
 | 0030–0039 | US #10 | 2FA / TOTP            |
 | 0040      | US #63 | Merge multi-heads     |
+| 0041      | US #54 | subscriptions.user_id index (tech-debt) |
 
 Name your migration files with the appropriate prefix, e.g.:
 `0010_add_verification_tokens.py` for US #8.

--- a/src/app/models/subscription.py
+++ b/src/app/models/subscription.py
@@ -39,7 +39,7 @@ class Subscription(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     plan: Mapped[SubscriptionPlan] = mapped_column(
         Enum(SubscriptionPlan, name="subscription_plan", create_constraint=False),

--- a/src/app/routers/sessions.py
+++ b/src/app/routers/sessions.py
@@ -1,6 +1,5 @@
 """Session management routes — US #7."""
 
-import hashlib
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request, status
@@ -19,12 +18,9 @@ from src.app.services.session import (
     revoke_session,
 )
 from src.app.services.token import create_refresh_token
+from src.app.utils.crypto import hash_token
 
 router = APIRouter(prefix="/api/v1/sessions", tags=["sessions"])
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
 
 
 @router.post(
@@ -40,7 +36,7 @@ async def create_user_session(
 ) -> SessionCreateResponse:
     """Create a new session for the authenticated user."""
     token = create_refresh_token()
-    token_hash = _hash_token(token)
+    token_hash = hash_token(token)
     session = await create_session(
         db=db,
         redis=redis,

--- a/src/app/services/token.py
+++ b/src/app/services/token.py
@@ -1,6 +1,5 @@
 """Token service — JWT issuance, validation, refresh, and revocation."""
 
-import hashlib
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -14,10 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.app.config import Settings
 from src.app.models.session import Session
 from src.app.services.keys import get_private_key, get_public_key, get_public_key_jwk
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
+from src.app.utils.crypto import hash_token
 
 
 def create_access_token(
@@ -71,7 +67,7 @@ async def store_refresh_token(
     user_agent: str | None = None,
 ) -> Session:
     """Store a hashed refresh token in the sessions table."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     expires_at = datetime.now(UTC) + timedelta(days=expires_days)
     session = Session(
         user_id=user_id,
@@ -87,7 +83,7 @@ async def store_refresh_token(
 
 async def validate_refresh_token(db: AsyncSession, refresh_token: str) -> Session | None:
     """Look up a refresh token and return the session if valid."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     now = datetime.now(UTC)
     result = await db.execute(
         select(Session).where(
@@ -101,7 +97,7 @@ async def validate_refresh_token(db: AsyncSession, refresh_token: str) -> Sessio
 
 async def revoke_refresh_token(db: AsyncSession, refresh_token: str) -> bool:
     """Revoke a refresh token. Returns True if a token was revoked."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     cursor_result: CursorResult[Any] = await db.execute(  # type: ignore[assignment]
         update(Session)
         .where(Session.token_hash == token_hash, Session.revoked_at.is_(None))

--- a/src/app/services/verification.py
+++ b/src/app/services/verification.py
@@ -6,7 +6,6 @@ and email dispatch.
 
 from __future__ import annotations
 
-import hashlib
 import html
 import secrets
 import uuid
@@ -21,10 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.app.config import Settings
 from src.app.models.user import User
 from src.app.models.verification_token import TokenType, VerificationToken
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
+from src.app.utils.crypto import hash_token
 
 
 async def check_rate_limit(
@@ -77,7 +73,7 @@ async def create_verification_token(
     await invalidate_existing_tokens(db, user_id)
 
     raw_token = secrets.token_urlsafe(32)
-    token_hash = _hash_token(raw_token)
+    token_hash = hash_token(raw_token)
     expires_at = datetime.now(UTC) + timedelta(hours=settings.VERIFICATION_TOKEN_EXPIRE_HOURS)
 
     verification_token = VerificationToken(
@@ -99,7 +95,7 @@ async def confirm_verification_token(
 
     Returns the User if successful, None if the token is invalid/expired/used.
     """
-    token_hash = _hash_token(raw_token)
+    token_hash = hash_token(raw_token)
     now = datetime.now(UTC)
 
     result = await db.execute(

--- a/src/app/utils/__init__.py
+++ b/src/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility helpers."""

--- a/src/app/utils/crypto.py
+++ b/src/app/utils/crypto.py
@@ -1,0 +1,12 @@
+"""Cryptographic helpers shared across services and routers."""
+
+import hashlib
+
+
+def hash_token(token: str) -> str:
+    """Return the SHA-256 hex digest of an opaque token.
+
+    Used to store refresh tokens and verification tokens at rest as a hash
+    rather than the raw value. Callers compare hashes, never raw tokens.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -20,12 +20,7 @@ from src.app.services.session import (
     update_session_activity,
 )
 from src.app.services.token import create_refresh_token
-
-
-def _hash_token(token: str) -> str:
-    import hashlib
-
-    return hashlib.sha256(token.encode()).hexdigest()
+from src.app.utils.crypto import hash_token
 
 
 @pytest.fixture
@@ -150,7 +145,7 @@ class TestCreateSession:
         self, db_session: AsyncSession, test_user: User, fake_redis: FakeRedis
     ) -> None:
         token = create_refresh_token()
-        token_hash = _hash_token(token)
+        token_hash = hash_token(token)
         session = await create_session(
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
@@ -187,7 +182,7 @@ class TestCreateSession:
                 db=db_session,
                 redis=fake_redis,  # type: ignore[arg-type]
                 user_id=test_user.id,
-                token_hash=_hash_token(token),
+                token_hash=hash_token(token),
                 ip_address=f"10.0.0.{i}",
             )
             session_ids.append(s.id)
@@ -198,7 +193,7 @@ class TestCreateSession:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(extra_token),
+            token_hash=hash_token(extra_token),
         )
 
         # Check oldest session is revoked
@@ -219,7 +214,7 @@ class TestListSessions:
                 db=db_session,
                 redis=fake_redis,  # type: ignore[arg-type]
                 user_id=test_user.id,
-                token_hash=_hash_token(token),
+                token_hash=hash_token(token),
             )
 
         sessions = await list_user_sessions(
@@ -237,7 +232,7 @@ class TestListSessions:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(token1),
+            token_hash=hash_token(token1),
         )
 
         token2 = create_refresh_token()
@@ -245,7 +240,7 @@ class TestListSessions:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(token2),
+            token_hash=hash_token(token2),
         )
 
         await revoke_session(
@@ -270,7 +265,7 @@ class TestListSessions:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(token),
+            token_hash=hash_token(token),
         )
 
         sessions = await list_user_sessions(
@@ -292,7 +287,7 @@ class TestRevokeSession:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(token),
+            token_hash=hash_token(token),
         )
 
         revoked = await revoke_session(
@@ -333,7 +328,7 @@ class TestRevokeSession:
             db=db_session,
             redis=fake_redis,  # type: ignore[arg-type]
             user_id=test_user.id,
-            token_hash=_hash_token(token),
+            token_hash=hash_token(token),
         )
 
         other_user_id = uuid.uuid4()
@@ -356,7 +351,7 @@ class TestRevokeAllSessions:
                 db=db_session,
                 redis=fake_redis,  # type: ignore[arg-type]
                 user_id=test_user.id,
-                token_hash=_hash_token(token),
+                token_hash=hash_token(token),
             )
 
         count = await revoke_all_sessions(
@@ -383,7 +378,7 @@ class TestRevokeAllSessions:
                 db=db_session,
                 redis=fake_redis,  # type: ignore[arg-type]
                 user_id=test_user.id,
-                token_hash=_hash_token(token),
+                token_hash=hash_token(token),
             )
             session_ids.append(s.id)
 

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -15,12 +15,12 @@ from src.app.services.keys import (
     get_public_key_jwk,
 )
 from src.app.services.token import (
-    _hash_token,
     create_access_token,
     create_refresh_token,
     decode_access_token,
     get_jwks,
 )
+from src.app.utils.crypto import hash_token
 
 
 def _test_settings() -> Settings:
@@ -179,9 +179,9 @@ class TestRefreshToken:
 
     def test_hash_is_deterministic(self) -> None:
         token = create_refresh_token()
-        assert _hash_token(token) == _hash_token(token)
+        assert hash_token(token) == hash_token(token)
 
     def test_different_tokens_different_hashes(self) -> None:
         t1 = create_refresh_token()
         t2 = create_refresh_token()
-        assert _hash_token(t1) != _hash_token(t2)
+        assert hash_token(t1) != hash_token(t2)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -24,13 +24,13 @@ from src.app.main import create_app
 from src.app.models.user import Base, User
 from src.app.models.verification_token import TokenType
 from src.app.services.verification import (
-    _hash_token,
     check_rate_limit,
     confirm_verification_token,
     create_verification_token,
     get_latest_verification_token,
     invalidate_existing_tokens,
 )
+from src.app.utils.crypto import hash_token
 
 # Generate a test RSA key pair (once per module)
 _test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -191,7 +191,7 @@ class TestCreateVerificationToken:
 
         latest = await get_latest_verification_token(db_session, test_user.id)
         assert latest is not None
-        assert latest.token_hash == _hash_token(raw_token)
+        assert latest.token_hash == hash_token(raw_token)
         assert latest.token_type == TokenType.email_verification
         assert latest.used_at is None
 
@@ -270,10 +270,10 @@ class TestInvalidateExistingTokens:
 class TestTokenHashing:
     def test_hash_deterministic(self) -> None:
         token = "test-token-123"
-        assert _hash_token(token) == _hash_token(token)
+        assert hash_token(token) == hash_token(token)
 
     def test_hash_different_tokens(self) -> None:
-        assert _hash_token("token-a") != _hash_token("token-b")
+        assert hash_token("token-a") != hash_token("token-b")
 
 
 # --- Endpoint integration tests ---


### PR DESCRIPTION
## Summary

Closes #54. Two independent tech-debt items, premise verified against wave-10 HEAD.

### 1. Dedup `_hash_token` helper

The SHA-256 token-hashing helper was defined **identically in three source modules**:
- `src/app/services/token.py`
- `src/app/routers/sessions.py`
- `src/app/services/verification.py`

…plus a **fourth ad-hoc copy** in `tests/test_session_service.py` (an inline `def _hash_token` with a function-local `import hashlib`).

Extracted to **`src/app/utils/crypto.py`** as `hash_token` and imported everywhere. New `src/app/utils/` package is the home for shared low-level helpers. `test_token_service.py` and `test_verification.py` previously imported the private `_hash_token` symbol straight from the service module — they now import the shared `hash_token`.

### 2. `subscriptions.user_id` index

`subscriptions` only had a **partial** unique index on `user_id` (`WHERE plan='trial' AND status='active'`). Equality lookups by `user_id` alone — `get_current_subscription`, `get_subscription_status`, `start_trial`, `cancel_subscription` — cannot use that partial index and fall back to a sequential scan as the table grows.

- Added `index=True` to `Subscription.user_id`
- Migration **0041** (`ix_subscriptions_user_id`) — chains off `0040`, the current single head
- `MIGRATION_RANGES.md` updated to record 0041 (tech-debt issues have no pre-reserved range)

## Test plan

- [x] `ENVIRONMENT=test uv run pytest` — full suite **259 passed**
- [x] `ruff check` + `ruff format --check` (src + tests + alembic) — clean
- [x] `make typecheck` (`mypy src/`) — clean, no issues in 47 files
- [x] `alembic heads` — reports `0041` as the single head (migration chains cleanly)
- [ ] `alembic upgrade head` against a live Postgres — **not run in this env** (no DB available). Pure additive DDL (`CREATE INDEX`), reversible via the migration's `downgrade()`. Recommend a post-merge runtime check or rely on deploy's alembic pre-deploy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
