### PR TITLE
tech-debt(US#70): assert redirect_uri in OAuth GET callback test (Gap-3-only re-scope)

### DIFF
--- a/tests/test_oauth_callback_get.py
+++ b/tests/test_oauth_callback_get.py
@@ -299,6 +299,71 @@ class TestOAuthCallbackGet:
         oauth_mock.get_user_info.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_exchange_code_called_with_configured_redirect_uri(
+        self,
+        client_factory: Any,
+        fake_user: User,
+    ) -> None:
+        """exchange_code must receive the redirect_uri built from AUTH_OAUTH_REDIRECT_BASE_URL.
+
+        Gap 3 on #70. The happy-path test asserts the redirect *response* but
+        never inspects what redirect_uri was handed to the provider. A prod
+        misconfig (AUTH_OAUTH_REDIRECT_BASE_URL unset/wrong) would pass every
+        other test and only fail at integration time with redirect_uri_mismatch.
+        """
+        state = "redirect-uri-state"
+        seed = {
+            f"oauth_state:{state}": json.dumps(
+                {"provider": "google", "code_verifier": "pkce-verifier"}
+            ),
+        }
+
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g-123",
+                email="mateo@example.com",
+                display_name="Mateo Test",
+                avatar_url=None,
+            )
+        )
+
+        with (
+            patch("src.app.routers.auth.get_oauth_provider", return_value=oauth_mock),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake_user, is_new_user=False),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc123", "state": state},
+                )
+
+        assert resp.status_code == 302
+        # _test_settings sets AUTH_OAUTH_REDIRECT_BASE_URL to this host; the
+        # handler appends /auth/oauth/{provider}/callback.
+        oauth_mock.exchange_code.assert_awaited_once_with(
+            "abc123",
+            "pkce-verifier",
+            "https://isnad-graph.noorinalabs.com/auth/oauth/google/callback",
+        )
+
+    @pytest.mark.asyncio
     async def test_state_is_consumed_exactly_once(self, client_factory: Any) -> None:
         """Replaying the callback URL with the same state must fail the second time."""
         state = "replay-state"


### PR DESCRIPTION
## Summary

Closes #70. Adds the one genuinely-missing test from the issue's 4-gap list and documents the re-scope of the other three.

`#70` enumerated 4 coverage gaps in `tests/test_oauth_callback_get.py`. Re-verified against wave-10 HEAD — only **Gap 3** is real:

| Gap | Status |
|-----|--------|
| 1 — `get_user_info` failure → `USER_INFO_FAILED` | **Already covered.** `test_user_info_failure_redirects_with_error` + `test_user_info_exception_logs_provider` exercise this path. They landed via #71's structured-logging work, which merged after #67 (the PR #70 was filed against). |
| 2 — `find_or_create_oauth_user` ValueError → `email_mismatch` | **Already covered.** `test_upsert_value_error_logs_warning` asserts `error=email_mismatch` on a `ValueError` from the upsert. Also landed via #71. |
| 3 — `redirect_uri` passed to `exchange_code` not asserted | **Genuinely missing — this PR.** |
| 4 — query-string base URL `?`→`&` separator-flipping | **Premise factually wrong — dropped, no separate issue.** See below. |

### What this PR adds

`test_exchange_code_called_with_configured_redirect_uri` — asserts `exchange_code` is awaited with the exact `redirect_uri` built from `AUTH_OAUTH_REDIRECT_BASE_URL` (`https://isnad-graph.noorinalabs.com/auth/oauth/google/callback`), not just call-count. The existing happy-path test asserts the redirect *response* but never inspects what the handler hands the provider — a prod misconfig of `AUTH_OAUTH_REDIRECT_BASE_URL` would pass every other test and only surface at integration time as `redirect_uri_mismatch`.

No handler change — pure test coverage expansion.

### Why Gap 4 is dropped

The issue claims `_build_error_redirect` "flips the separator to `&`" when the base URL already contains a `?`. It does not — and never has. `_build_post_login_url` (auth.py:265) does:

```
base = (settings.AUTH_OAUTH_POST_LOGIN_URL or "/").rstrip("/")
path = f"{base}/{urllib.parse.quote(provider, safe='')}"
return f"{path}?{urllib.parse.urlencode(params)}"
```

There is no separator-flipping branch to test. Worse, a query-string base like `/auth/callback?foo=bar` would produce `/auth/callback?foo=bar/google?error=...` — malformed, because the `/{provider}` segment lands *inside* the query string. Fixing that would require a handler change, which #70's acceptance criteria explicitly forbid ("No change to handler code"). There is no testable behavior here without a code change that's out of scope. (Note: `AUTH_OAUTH_POST_LOGIN_URL` open-redirect / format hardening is separately tracked under US#69.)

## Test plan

- [x] `ENVIRONMENT=test uv run pytest tests/test_oauth_callback_get.py` — 14 passed (was 13)
- [x] `ENVIRONMENT=test uv run pytest` — full suite 260 passed
- [x] `ruff check` + `ruff format --check` on the test file — clean
- [x] `make typecheck` scope (`src/` only) — unaffected by this test-only change

Note: supersedes PR #112 (same commits/SHA `0cd4a87`) — recreated only to move the head branch from the mis-named `M.Rossi/` prefix to `M.Salazar/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
