### PR TITLE
tech-debt(auth): validate AUTH_OAUTH_POST_LOGIN_URL at boot — open-redirect hardening (#69)

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -10,6 +10,15 @@ _PROD_LIKE_ENVIRONMENTS = frozenset({"production", "staging"})
 _ALLOWED_ENVIRONMENTS = frozenset({"development", "test", "staging", "production"})
 
 
+def _host_of(url: str) -> str | None:
+    """Return the lowercased hostname of an absolute URL, or None if it has no host.
+
+    Used to build the AUTH_OAUTH_POST_LOGIN_URL allowlist from other URL settings.
+    """
+    parsed = urlparse(url)
+    return parsed.hostname.lower() if parsed.hostname else None
+
+
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
@@ -157,6 +166,86 @@ class Settings(BaseSettings):
                 "ENVIRONMENT=test (no HTTP downgrade)"
             )
             raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_oauth_post_login_url(self) -> Self:
+        """Open-redirect hardening for AUTH_OAUTH_POST_LOGIN_URL (#69).
+
+        The OAuth callback redirects the browser — with a freshly minted access
+        token attached — to this URL. It is operator-controlled (an env var, no
+        `?next=` override) so it is not an exploitable open redirect today, but a
+        misconfigured or compromised deploy config should not be able to divert
+        token-bearing traffic to an attacker host. Validation runs at boot so a
+        bad value fails fast rather than at request time.
+
+        Accepted:
+          - a same-origin relative URL starting with a single `/`, OR
+          - an absolute URL whose host is in the allowlist derived from
+            AUTH_OAUTH_REDIRECT_BASE_URL + CORS_ORIGINS.
+
+        Rejected everywhere: `javascript:` / `data:` schemes, and
+        protocol-relative `//host` URLs (urlparse reads `//host` as netloc with
+        an empty scheme — a classic open-redirect bypass). Rejected outside
+        ENVIRONMENT=development/test: absolute URLs with a non-`https` scheme.
+        """
+        value = self.AUTH_OAUTH_POST_LOGIN_URL
+        if not value:
+            msg = "AUTH_OAUTH_POST_LOGIN_URL must not be empty"
+            raise ValueError(msg)
+
+        parsed = urlparse(value)
+
+        # Protocol-relative (`//evil.com/path`): no scheme but a netloc. urlparse
+        # treats this as having a host — reject before the relative-path branch.
+        if not parsed.scheme and parsed.netloc:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL must not be protocol-relative "
+                f"(`//host`), got: {value!r}"
+            )
+            raise ValueError(msg)
+
+        # Same-origin relative URL: starts with a single `/` (not `//`), no scheme,
+        # no netloc. This is the safe common case.
+        if not parsed.scheme and not parsed.netloc:
+            if not value.startswith("/"):
+                msg = (
+                    "AUTH_OAUTH_POST_LOGIN_URL must be an absolute https URL or a "
+                    f"same-origin path starting with '/', got: {value!r}"
+                )
+                raise ValueError(msg)
+            return self
+
+        # Absolute URL from here on. Reject dangerous schemes outright.
+        if parsed.scheme not in {"http", "https"}:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL scheme must be https (or http in "
+                f"development/test), got: {parsed.scheme!r}"
+            )
+            raise ValueError(msg)
+
+        # Non-https absolute URL only tolerated in development/test.
+        if parsed.scheme != "https" and self.ENVIRONMENT not in {"development", "test"}:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL must use https:// outside "
+                f"ENVIRONMENT=development/test, got: {value!r}"
+            )
+            raise ValueError(msg)
+
+        # Host must be in the allowlist derived from the other trusted URL settings.
+        allowed_hosts = {_host_of(self.AUTH_OAUTH_REDIRECT_BASE_URL)}
+        allowed_hosts.update(_host_of(origin) for origin in self.CORS_ORIGINS)
+        allowed_hosts.discard(None)
+
+        host = parsed.hostname.lower() if parsed.hostname else None
+        if host not in allowed_hosts:
+            msg = (
+                f"AUTH_OAUTH_POST_LOGIN_URL host {host!r} is not in the allowlist "
+                f"derived from AUTH_OAUTH_REDIRECT_BASE_URL + CORS_ORIGINS "
+                f"({sorted(h for h in allowed_hosts if h)}), got: {value!r}"
+            )
+            raise ValueError(msg)
+
         return self
 
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -214,6 +214,19 @@ class Settings(BaseSettings):
                     f"same-origin path starting with '/', got: {value!r}"
                 )
                 raise ValueError(msg)
+            # A leading `/` followed by `/` or `\` is not same-origin: browsers
+            # normalize `\` -> `/` in http(s) URLs per the WHATWG URL spec, so
+            # `/\host` becomes the protocol-relative `//host` at navigation time
+            # — a classic open-redirect bypass that slips past urlparse (which
+            # does not treat `\` as a netloc delimiter). Reject any backslash:
+            # there is no legitimate use for one in this path, and a blanket
+            # reject closes the whole variant family (`/\`, `/foo\@host`, ...).
+            if value.startswith(("//", "/\\")) or "\\" in value:
+                msg = (
+                    "AUTH_OAUTH_POST_LOGIN_URL must not contain backslashes or be "
+                    f"protocol-relative, got: {value!r}"
+                )
+                raise ValueError(msg)
             return self
 
         # Absolute URL from here on. Reject dangerous schemes outright.

--- a/tests/test_config_post_login_url.py
+++ b/tests/test_config_post_login_url.py
@@ -98,3 +98,15 @@ class TestPostLoginUrlRejected:
     def test_relative_url_without_leading_slash_rejected(self) -> None:
         with pytest.raises(ValidationError, match="starting with '/'"):
             _make_settings(AUTH_OAUTH_POST_LOGIN_URL="auth/callback")
+
+    def test_backslash_relative_url_rejected(self) -> None:
+        # `/\evil.com` passes urlparse as a relative path (backslash is not a
+        # netloc delimiter), but browsers normalize `\`->`/`, turning it into the
+        # protocol-relative `//evil.com` at navigation time — CWE-601 bypass.
+        with pytest.raises(ValidationError, match="must not contain backslashes"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/\\evil.com")
+
+    def test_backslash_anywhere_in_relative_url_rejected(self) -> None:
+        # Blanket backslash reject — not just the leading `/\` case.
+        with pytest.raises(ValidationError, match="must not contain backslashes"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/auth\\callback")

--- a/tests/test_config_post_login_url.py
+++ b/tests/test_config_post_login_url.py
@@ -1,0 +1,100 @@
+"""Tests for AUTH_OAUTH_POST_LOGIN_URL validation — open-redirect hardening (#69).
+
+The OAuth callback redirects the browser, with a freshly minted access token
+attached, to AUTH_OAUTH_POST_LOGIN_URL. It is operator-controlled today (env var,
+no `?next=` override) so not an exploitable open redirect — this validator is
+defence-in-depth: a misconfigured/compromised deploy config must fail fast at
+boot rather than divert token-bearing traffic to an attacker host.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.app.config import Settings
+
+
+def _make_settings(**overrides: object) -> Settings:
+    """Build a Settings instance with sane defaults for the post-login-URL tests.
+
+    Defaults ENVIRONMENT=production so the strict (https-only, allowlisted-host)
+    branch is exercised unless a test opts into development/test.
+    """
+    defaults: dict[str, object] = {
+        "ENVIRONMENT": "production",
+        "AUTH_OAUTH_REDIRECT_BASE_URL": "https://user-service.noorinalabs.com",
+        "CORS_ORIGINS": ["https://app.noorinalabs.com", "https://noorinalabs.com"],
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestPostLoginUrlAccepted:
+    def test_relative_url_accepted(self) -> None:
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "/auth/callback"
+
+    def test_default_value_is_valid(self) -> None:
+        # The shipped default must pass its own validator.
+        s = _make_settings()
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "/auth/callback"
+
+    def test_absolute_url_on_redirect_base_host_accepted(self) -> None:
+        s = _make_settings(
+            AUTH_OAUTH_POST_LOGIN_URL="https://user-service.noorinalabs.com/auth/callback"
+        )
+        assert s.AUTH_OAUTH_POST_LOGIN_URL.endswith("/auth/callback")
+
+    def test_absolute_url_on_cors_origin_host_accepted(self) -> None:
+        # Host present in CORS_ORIGINS but not AUTH_OAUTH_REDIRECT_BASE_URL.
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://app.noorinalabs.com/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "https://app.noorinalabs.com/auth/callback"
+
+    def test_host_match_is_case_insensitive(self) -> None:
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://APP.NoorinALabs.com/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL.startswith("https://APP")
+
+    def test_http_absolute_url_allowed_in_development(self) -> None:
+        # localhost dev: CORS_ORIGINS carries the http host, ENVIRONMENT=development.
+        s = _make_settings(
+            ENVIRONMENT="development",
+            AUTH_OAUTH_REDIRECT_BASE_URL="http://localhost:8000",
+            CORS_ORIGINS=["http://localhost:3000"],
+            AUTH_OAUTH_POST_LOGIN_URL="http://localhost:3000/auth/callback",
+        )
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "http://localhost:3000/auth/callback"
+
+
+class TestPostLoginUrlRejected:
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must not be empty"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="")
+
+    def test_protocol_relative_url_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="protocol-relative"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="//evil.com/auth/callback")
+
+    def test_javascript_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="scheme must be https"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="javascript:alert(document.cookie)")
+
+    def test_data_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="scheme must be https"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="data:text/html,<script>1</script>")
+
+    def test_off_allowlist_host_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not in the allowlist"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://evil.com/auth/callback")
+
+    def test_http_absolute_url_rejected_in_production(self) -> None:
+        # Host would be allowlisted, but http:// is rejected outside dev/test.
+        with pytest.raises(ValidationError, match="must use https"):
+            _make_settings(
+                CORS_ORIGINS=["http://app.noorinalabs.com"],
+                AUTH_OAUTH_POST_LOGIN_URL="http://app.noorinalabs.com/auth/callback",
+            )
+
+    def test_relative_url_without_leading_slash_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="starting with '/'"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="auth/callback")


### PR DESCRIPTION
## Summary

The OAuth callback redirects the browser — with a freshly minted access token attached — to `settings.AUTH_OAUTH_POST_LOGIN_URL` with **no validation**. The value is operator-controlled (an env var, no `?next=` query override) so it is **not an exploitable open redirect today**. This PR is defence-in-depth: a misconfigured or compromised deploy config should not be able to divert token-bearing traffic to an attacker-controlled host.

### Changes (`src/app/config.py`)

Adds a `model_validator(mode="after")` on `Settings` — runs at **boot**, so a bad value fails fast rather than at request time:

- **Accepts** a same-origin relative URL starting with a single `/`, OR an absolute URL whose host is in an allowlist derived from `AUTH_OAUTH_REDIRECT_BASE_URL` + `CORS_ORIGINS`.
- **Rejects everywhere** protocol-relative `//host` URLs (`urlparse` reads `//host` as a netloc with empty scheme — a classic open-redirect bypass) and non-http(s) schemes (`javascript:`, `data:`, …).
- **Rejects** non-`https` absolute URLs outside `ENVIRONMENT=development/test`.

Follows the existing `_guard_oauth_provider_base_url_override` pattern in the same file. New `_host_of` helper builds the allowlist from the other trusted URL settings. The shipped default (`/auth/callback`, relative) passes its own validator.

### Tests (`tests/test_config_post_login_url.py`, new — 13 tests)

- **Accepted:** relative URL, shipped default, allowlisted-absolute on the redirect-base host, allowlisted-absolute on a CORS-origin host, case-insensitive host match, `http://` absolute in development.
- **Rejected:** empty string, protocol-relative `//evil.com`, `javascript:`, `data:`, off-allowlist host, `http://` absolute in production, relative URL without leading `/`.

## Test plan

- [x] `make test` — 272 passed (13 new); re-run green after rebase onto current wave-10 HEAD
- [x] `make lint` — clean
- [x] `make typecheck` — clean (mypy strict, `src/`); also ran mypy on the new test file — clean
- [x] `make format` — no changes
- [x] Verified no other `Settings(...)` construction in the suite passes a non-relative `AUTH_OAUTH_POST_LOGIN_URL` that would now fail (all use the `/auth/callback` default or set it explicitly to `/auth/callback`)

Closes #69
