### PR TITLE
refactor(US#56): consolidate duplicated test fixtures into conftest + add missing coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,334 @@
-from collections.abc import AsyncGenerator
+"""Shared pytest fixtures for the user-service test suite.
+
+Before US#56 each of test_users_crud.py / test_subscriptions.py /
+test_verification.py generated its own RSA key pair, defined its own
+`_make_token` / `_auth_header` helpers, and rolled its own
+`db_engine` / `db_session` / `seed_roles` / `admin_user` / `regular_user` /
+`client` fixture chain — all byte-identical or near-identical. This module
+consolidates them so individual test files only declare what is genuinely
+specific to them.
+
+The RSA key pair is generated once per test session (module-level constants)
+— keygen is the slow part, so sharing it across the whole run matters.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Callable
+from datetime import UTC, datetime, timedelta
+from types import TracebackType
+from typing import Any
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from src.app.config import Settings, get_settings
+from src.app.database import get_db_session
 from src.app.main import create_app
+from src.app.models.role import Role, UserRole
+from src.app.models.user import Base, User
+
+# --- RSA key pair (generated once per test session) ---
+
+_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+TEST_PRIVATE_PEM = _test_private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode()
+TEST_PUBLIC_PEM = (
+    _test_private_key.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+
+# --- Token helpers ---
+
+
+def make_token(
+    user_id: uuid.UUID,
+    roles: list[str] | None = None,
+    expires_delta: timedelta | None = None,
+) -> str:
+    """Sign an RS256 access token for `user_id` with the test private key.
+
+    Mirrors the shape the service issues: `sub`, `exp`, optional `roles`.
+    """
+    exp = datetime.now(UTC) + (expires_delta or timedelta(hours=1))
+    payload: dict[str, Any] = {"sub": str(user_id), "exp": exp}
+    if roles:
+        payload["roles"] = roles
+    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
+
+
+def auth_header(user: User, roles: list[str] | None = None) -> dict[str, str]:
+    """Return an Authorization header carrying a freshly-signed token for `user`."""
+    return {"Authorization": f"Bearer {make_token(user.id, roles=roles)}"}
+
+
+# --- Redis fake (used by session HTTP + service tests) ---
+
+
+class FakeRedisPipeline:
+    """Minimal fake pipeline supporting async context manager and the ops we use."""
+
+    def __init__(self, store: dict[str, object]) -> None:
+        self._store = store
+
+    async def __aenter__(self) -> FakeRedisPipeline:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    async def hset(self, key: str, mapping: dict[str, str] | None = None, **kwargs: str) -> int:
+        data = mapping or kwargs
+        if key not in self._store:
+            self._store[key] = {}
+        store_hash: dict[str, bytes] = self._store[key]  # type: ignore[assignment]
+        for k, v in data.items():
+            store_hash[k] = v.encode() if isinstance(v, str) else v  # type: ignore[assignment]
+        return len(data)
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        return True
+
+    async def sadd(self, key: str, *values: str) -> int:
+        if key not in self._store:
+            self._store[key] = set()
+        store_set: set[str] = self._store[key]  # type: ignore[assignment]
+        for v in values:
+            store_set.add(str(v))
+        return len(values)
+
+    async def srem(self, key: str, *values: str) -> int:
+        if key in self._store and isinstance(self._store[key], set):
+            store_set: set[str] = self._store[key]  # type: ignore[assignment]
+            for v in values:
+                store_set.discard(str(v))
+        return 1
+
+    async def delete(self, key: str) -> int:
+        if key in self._store:
+            del self._store[key]
+            return 1
+        return 0
+
+    async def execute(self) -> list[object]:
+        return []
+
+
+class FakeRedis:
+    """In-memory Redis fake supporting the operations used by the session service."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, object] = {}
+
+    def pipeline(self) -> FakeRedisPipeline:
+        return FakeRedisPipeline(self._store)
+
+    async def hget(self, key: str, field: str) -> bytes | None:
+        h = self._store.get(key)
+        if isinstance(h, dict):
+            return h.get(field)  # type: ignore[return-value]
+        return None
+
+    async def hset(self, key: str, field: str, value: str) -> int:
+        if key not in self._store:
+            self._store[key] = {}
+        store_hash: dict[str, bytes] = self._store[key]  # type: ignore[assignment]
+        store_hash[field] = value.encode()
+        return 1
+
+    async def exists(self, key: str) -> int:
+        return 1 if key in self._store else 0
+
+    async def delete(self, key: str) -> int:
+        if key in self._store:
+            del self._store[key]
+            return 1
+        return 0
 
 
 @pytest.fixture
-async def client() -> AsyncGenerator[AsyncClient, None]:
+def fake_redis() -> FakeRedis:
+    return FakeRedis()
+
+
+# --- Database fixtures ---
+
+
+@pytest.fixture
+async def db_engine() -> AsyncGenerator[Any, None]:
+    """In-memory SQLite engine with the full schema and FK enforcement on.
+
+    SQLite does not enforce foreign keys by default; the PRAGMA matches the
+    behaviour the Postgres-backed prod path gives us.
+    """
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn: Any, _connection_record: Any) -> None:
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(db_engine: Any) -> AsyncGenerator[AsyncSession, None]:
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture
+async def seed_roles(db_session: AsyncSession) -> dict[str, Role]:
+    """Seed the four platform roles and return them keyed by name."""
+    roles: dict[str, Role] = {}
+    for name, desc in [
+        ("admin", "Full platform administration access"),
+        ("researcher", "Access to research tools and datasets"),
+        ("reader", "Read-only access to public content"),
+        ("trial", "Time-limited trial access"),
+    ]:
+        role = Role(name=name, description=desc)
+        db_session.add(role)
+        roles[name] = role
+    await db_session.commit()
+    return roles
+
+
+@pytest.fixture
+async def admin_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
+    user = User(
+        email="admin@test.com",
+        display_name="Admin User",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=user.id, role_id=seed_roles["admin"].id, granted_by=user.id))
+    await db_session.commit()
+    return user
+
+
+@pytest.fixture
+async def regular_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
+    user = User(
+        email="reader@test.com",
+        display_name="Regular User",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=user.id, role_id=seed_roles["reader"].id))
+    await db_session.commit()
+    return user
+
+
+# --- Settings + client fixtures ---
+
+
+def build_test_settings(**overrides: Any) -> Settings:
+    """Construct a Settings for tests — RS256 public key wired, SQLite URL.
+
+    `overrides` lets a test file add what it needs (e.g.
+    `WEBHOOK_SIGNING_SECRET`) without re-declaring the whole object.
+    """
+    base: dict[str, Any] = {
+        "JWT_PUBLIC_KEY": TEST_PUBLIC_PEM,
+        "DATABASE_URL": "sqlite+aiosqlite://",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return build_test_settings()
+
+
+@pytest.fixture
+async def client(
+    db_engine: Any,
+    settings: Settings,
+) -> AsyncGenerator[AsyncClient, None]:
+    """HTTP client bound to the app with DB + settings dependency overrides.
+
+    Test files that need extra settings (e.g. a webhook secret) override the
+    `settings` fixture locally — the `client` fixture picks it up by injection.
+    """
     app = create_app()
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_db_session] = _override_db
+
     transport = ASGITransport(app=app)  # type: ignore[arg-type]
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+
+
+@pytest.fixture
+def client_factory(db_engine: Any) -> Callable[..., Any]:
+    """Factory for a client with caller-supplied settings overrides + redis dep.
+
+    Some suites (session HTTP tests) need a FakeRedis wired into `get_redis`
+    and per-test settings; this returns a builder so they don't each rebuild
+    the override boilerplate.
+    """
+
+    def _make(
+        settings_overrides: dict[str, Any] | None = None,
+        redis: Any | None = None,
+    ) -> AsyncClient:
+        from src.app.database import get_redis
+
+        app = create_app()
+        test_settings = build_test_settings(**(settings_overrides or {}))
+        session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+        async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+            async with session_factory() as session:
+                yield session
+
+        app.dependency_overrides[get_settings] = lambda: test_settings
+        app.dependency_overrides[get_db_session] = _override_db
+        if redis is not None:
+
+            async def _override_redis() -> AsyncGenerator[Any, None]:
+                yield redis
+
+            app.dependency_overrides[get_redis] = _override_redis
+
+        transport = ASGITransport(app=app)  # type: ignore[arg-type]
+        return AsyncClient(transport=transport, base_url="http://test", follow_redirects=False)
+
+    return _make

--- a/tests/test_database_lifecycle.py
+++ b/tests/test_database_lifecycle.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from src.app import database
@@ -29,3 +31,37 @@ async def test_close_db_disposes_engine(monkeypatch: pytest.MonkeyPatch) -> None
     assert disposed, "close_db() must dispose the engine"
     assert database._engine is None
     assert database._async_session_factory is None
+
+
+@pytest.mark.asyncio
+async def test_close_db_noop_when_uninitialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_db() must not raise if the engine was never initialized."""
+    monkeypatch.setattr(database, "_engine", None)
+    monkeypatch.setattr(database, "_async_session_factory", None)
+
+    await database.close_db()
+
+    assert database._engine is None
+    assert database._async_session_factory is None
+
+
+@pytest.mark.asyncio
+async def test_close_redis_closes_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_redis() must call aclose() on the client and clear the module global."""
+    fake_client = AsyncMock()
+    monkeypatch.setattr(database, "_redis_client", fake_client)
+
+    await database.close_redis()
+
+    fake_client.aclose.assert_awaited_once()
+    assert database._redis_client is None
+
+
+@pytest.mark.asyncio
+async def test_close_redis_noop_when_uninitialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close_redis() must not raise if Redis was never initialized."""
+    monkeypatch.setattr(database, "_redis_client", None)
+
+    await database.close_redis()
+
+    assert database._redis_client is None

--- a/tests/test_oauth_callback_get.py
+++ b/tests/test_oauth_callback_get.py
@@ -435,6 +435,86 @@ class TestOAuthCallbackGet:
                 assert "error=invalid_state" in second.headers["location"]
 
 
+class TestOAuthToTokenFlow:
+    """End-to-end: OAuth callback issues a token, then /auth/token/validate
+    accepts it (US#56 missing coverage).
+
+    The individual legs are tested elsewhere — callback→redirect above,
+    validate→200 in test_auth_endpoints.py — but nothing chains them. This
+    pins that the access token the callback mints is one the validate
+    endpoint actually accepts (same signing keypair, well-formed claims).
+    """
+
+    @pytest.mark.asyncio
+    async def test_callback_issued_token_passes_validate(
+        self,
+        client_factory: Any,
+        fake_user: User,
+    ) -> None:
+        state = "e2e-state-token"
+        seed = {
+            f"oauth_state:{state}": json.dumps(
+                {"provider": "google", "code_verifier": "pkce-verifier"}
+            ),
+        }
+
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g-123",
+                email="mateo@example.com",
+                display_name="Mateo Test",
+                avatar_url=None,
+            )
+        )
+
+        with (
+            patch(
+                "src.app.routers.auth.get_oauth_provider",
+                return_value=oauth_mock,
+            ),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake_user, is_new_user=False),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                callback_resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc123", "state": state},
+                )
+                assert callback_resp.status_code == 302
+                # Token is delivered in the URL fragment (#68).
+                fragment = parse_qs(urlparse(callback_resp.headers["location"]).fragment)
+                token = fragment["token"][0]
+                assert token
+
+                # Feed the freshly-issued token straight back to validate.
+                validate_resp = await client.get(
+                    "/auth/token/validate",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+
+        assert validate_resp.status_code == 200
+        data = validate_resp.json()
+        assert data["valid"] is True
+        assert data["user_id"] == str(fake_user.id)
+        assert data["email"] == fake_user.email
+
+
 class TestPostCallbackRemoved:
     """The POST callback was dead code (no frontend caller); #66 removed it."""
 

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -1,0 +1,136 @@
+"""HTTP-level tests for the session management router (US#56 missing coverage).
+
+`test_session_service.py` exercises the service layer directly; this module
+covers the router contract — auth gating, status codes, response schemas, and
+the create/list/revoke/revoke-all round trips — through the ASGI app with a
+FakeRedis wired into the `get_redis` dependency.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from src.app.models.user import User
+from tests.conftest import FakeRedis, auth_header
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def regular_user(db_session: Any) -> User:
+    """A plain active user — session endpoints need no role, just authentication."""
+    user = User(
+        email="sessions@test.com",
+        display_name="Session User",
+        email_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+@pytest.fixture
+def session_client(client_factory: Callable[..., Any], fake_redis: FakeRedis) -> AsyncClient:
+    """A client with a FakeRedis bound to `get_redis`."""
+    return client_factory(redis=fake_redis)
+
+
+class TestCreateSession:
+    async def test_create_returns_201_with_token(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            resp = await client.post("/api/v1/sessions", headers=auth_header(regular_user))
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "session_id" in body
+        assert body["refresh_token"]
+        assert "expires_at" in body
+
+    async def test_create_requires_auth(self, session_client: AsyncClient) -> None:
+        async with session_client as client:
+            resp = await client.post("/api/v1/sessions")
+        assert resp.status_code == 422  # missing Authorization header
+
+    async def test_create_rejects_bad_token(self, session_client: AsyncClient) -> None:
+        async with session_client as client:
+            resp = await client.post(
+                "/api/v1/sessions",
+                headers={"Authorization": "Bearer not-a-real-token"},
+            )
+        assert resp.status_code == 401
+
+
+class TestListSessions:
+    async def test_list_empty(self, session_client: AsyncClient, regular_user: User) -> None:
+        async with session_client as client:
+            resp = await client.get("/api/v1/sessions", headers=auth_header(regular_user))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 0
+        assert body["sessions"] == []
+
+    async def test_list_reflects_created_session(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            headers = auth_header(regular_user)
+            await client.post("/api/v1/sessions", headers=headers)
+            resp = await client.get("/api/v1/sessions", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert len(body["sessions"]) == 1
+
+    async def test_list_requires_auth(self, session_client: AsyncClient) -> None:
+        async with session_client as client:
+            resp = await client.get("/api/v1/sessions")
+        assert resp.status_code == 422
+
+
+class TestRevokeSession:
+    async def test_revoke_existing_returns_204(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            headers = auth_header(regular_user)
+            created = await client.post("/api/v1/sessions", headers=headers)
+            session_id = created.json()["session_id"]
+            resp = await client.delete(f"/api/v1/sessions/{session_id}", headers=headers)
+        assert resp.status_code == 204
+
+    async def test_revoke_unknown_returns_404(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            resp = await client.delete(
+                f"/api/v1/sessions/{uuid.uuid4()}", headers=auth_header(regular_user)
+            )
+        assert resp.status_code == 404
+
+
+class TestRevokeAllSessions:
+    async def test_revoke_all_returns_count(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            headers = auth_header(regular_user)
+            await client.post("/api/v1/sessions", headers=headers)
+            await client.post("/api/v1/sessions", headers=headers)
+            resp = await client.delete("/api/v1/sessions", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["revoked_count"] == 2
+
+    async def test_revoke_all_with_no_sessions(
+        self, session_client: AsyncClient, regular_user: User
+    ) -> None:
+        async with session_client as client:
+            resp = await client.delete("/api/v1/sessions", headers=auth_header(regular_user))
+        assert resp.status_code == 200
+        assert resp.json()["revoked_count"] == 0

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,172 +1,35 @@
-"""Tests for Subscription API endpoints and service logic."""
+"""Tests for Subscription API endpoints and service logic.
+
+Shared fixtures (RSA keygen, token helpers, db_engine/db_session/seed_roles/
+admin_user/regular_user/client) live in tests/conftest.py — see US#56. This
+module overrides the `settings` fixture so the `client` picks up the webhook
+signing secret the subscription webhook endpoint needs.
+"""
 
 import hashlib
 import hmac as hmac_mod
 import json
 import uuid
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from httpx import ASGITransport, AsyncClient
-from jose import jwt
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.app.config import Settings
-from src.app.database import get_db_session
-from src.app.main import create_app
-from src.app.models.role import Role, UserRole
 from src.app.models.subscription import Subscription, SubscriptionPlan, SubscriptionStatus
-from src.app.models.user import Base, User
+from src.app.models.user import User
 from src.app.services import subscription as sub_svc
+from tests.conftest import auth_header as _auth_header
+from tests.conftest import build_test_settings
 
 WEBHOOK_SECRET = "test-webhook-secret-123"
 
-_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-TEST_PRIVATE_PEM = _test_private_key.private_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PrivateFormat.PKCS8,
-    encryption_algorithm=serialization.NoEncryption(),
-).decode()
-TEST_PUBLIC_PEM = (
-    _test_private_key.public_key()
-    .public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode()
-)
-
-
-def _make_token(
-    user_id: uuid.UUID,
-    roles: list[str] | None = None,
-    expires_delta: timedelta | None = None,
-) -> str:
-    exp = datetime.now(UTC) + (expires_delta or timedelta(hours=1))
-    payload = {"sub": str(user_id), "exp": exp}
-    if roles:
-        payload["roles"] = roles  # type: ignore[assignment]
-    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
-
 
 @pytest.fixture
-async def db_engine():  # type: ignore[no-untyped-def]
-    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
-
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def, type-arg]
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-    async with session_factory() as session:
-        yield session
-
-
-@pytest.fixture
-async def seed_roles(db_session: AsyncSession) -> dict[str, Role]:
-    roles = {}
-    for name, desc in [
-        ("admin", "Full platform administration access"),
-        ("researcher", "Access to research tools and datasets"),
-        ("reader", "Read-only access to public content"),
-        ("trial", "Time-limited trial access"),
-    ]:
-        role = Role(name=name, description=desc)
-        db_session.add(role)
-        roles[name] = role
-    await db_session.commit()
-    return roles
-
-
-@pytest.fixture
-async def admin_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
-    user = User(
-        email="admin@test.com",
-        display_name="Admin User",
-        email_verified=True,
-        is_active=True,
-    )
-    db_session.add(user)
-    await db_session.flush()
-
-    user_role = UserRole(
-        user_id=user.id,
-        role_id=seed_roles["admin"].id,
-        granted_by=user.id,
-    )
-    db_session.add(user_role)
-    await db_session.commit()
-    return user
-
-
-@pytest.fixture
-async def regular_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
-    user = User(
-        email="reader@test.com",
-        display_name="Regular User",
-        email_verified=True,
-        is_active=True,
-    )
-    db_session.add(user)
-    await db_session.flush()
-
-    user_role = UserRole(
-        user_id=user.id,
-        role_id=seed_roles["reader"].id,
-    )
-    db_session.add(user_role)
-    await db_session.commit()
-    return user
-
-
-@pytest.fixture
-async def client(
-    db_engine,  # type: ignore[no-untyped-def]
-    db_session: AsyncSession,
-) -> AsyncGenerator[AsyncClient, None]:
-    app = create_app()
-
-    def _override_settings() -> Settings:
-        return Settings(
-            JWT_PUBLIC_KEY=TEST_PUBLIC_PEM,
-            DATABASE_URL="sqlite+aiosqlite://",
-            WEBHOOK_SIGNING_SECRET=WEBHOOK_SECRET,
-        )
-
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-
-    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
-        async with session_factory() as session:
-            yield session
-
-    from src.app.config import get_settings
-
-    app.dependency_overrides[get_settings] = _override_settings
-    app.dependency_overrides[get_db_session] = _override_db
-
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
-
-
-def _auth_header(user: User) -> dict[str, str]:
-    token = _make_token(user.id)
-    return {"Authorization": f"Bearer {token}"}
+def settings() -> Settings:
+    """Override the conftest `settings` fixture to wire the webhook secret."""
+    return build_test_settings(WEBHOOK_SIGNING_SECRET=WEBHOOK_SECRET)
 
 
 def _webhook_signature(body: bytes) -> str:
@@ -240,6 +103,63 @@ class TestSubscriptionService:
         await db_session.commit()
         status = await sub_svc.get_subscription_status(db_session, regular_user.id)
         assert status == "expired"
+
+    @pytest.mark.asyncio
+    async def test_expire_lapsed_marks_active_past_due_as_expired(
+        self, db_session: AsyncSession, regular_user: User
+    ) -> None:
+        """expire_lapsed_subscriptions mutates an active-but-past-due sub to expired.
+
+        Unlike get_subscription_status (a pure read), this writes the status
+        back — the row itself must change, not just the computed string.
+        """
+        sub = Subscription(
+            user_id=regular_user.id,
+            plan=SubscriptionPlan.trial,
+            status=SubscriptionStatus.active,
+            starts_at=datetime.now(UTC) - timedelta(days=15),
+            expires_at=datetime.now(UTC) - timedelta(days=1),
+        )
+        db_session.add(sub)
+        await db_session.commit()
+
+        await sub_svc.expire_lapsed_subscriptions(db_session, regular_user.id)
+        await db_session.commit()
+
+        refreshed = await sub_svc.get_current_subscription(db_session, regular_user.id)
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.expired
+
+    @pytest.mark.asyncio
+    async def test_expire_lapsed_leaves_active_in_date_untouched(
+        self, db_session: AsyncSession, regular_user: User
+    ) -> None:
+        """An active subscription not yet past expires_at must stay active."""
+        sub = Subscription(
+            user_id=regular_user.id,
+            plan=SubscriptionPlan.researcher,
+            status=SubscriptionStatus.active,
+            starts_at=datetime.now(UTC) - timedelta(days=1),
+            expires_at=datetime.now(UTC) + timedelta(days=30),
+        )
+        db_session.add(sub)
+        await db_session.commit()
+
+        await sub_svc.expire_lapsed_subscriptions(db_session, regular_user.id)
+        await db_session.commit()
+
+        refreshed = await sub_svc.get_current_subscription(db_session, regular_user.id)
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.active
+
+    @pytest.mark.asyncio
+    async def test_expire_lapsed_noop_when_no_subscription(
+        self, db_session: AsyncSession, regular_user: User
+    ) -> None:
+        """expire_lapsed_subscriptions must not raise for a user with no subscription."""
+        await sub_svc.expire_lapsed_subscriptions(db_session, regular_user.id)
+        await db_session.commit()
+        assert await sub_svc.get_current_subscription(db_session, regular_user.id) is None
 
 
 # --- API endpoint tests ---

--- a/tests/test_users_crud.py
+++ b/tests/test_users_crud.py
@@ -1,168 +1,17 @@
-"""Tests for User CRUD API and role management endpoints."""
+"""Tests for User CRUD API and role management endpoints.
+
+Shared fixtures (RSA keygen, token helpers, db_engine/db_session/seed_roles/
+admin_user/regular_user/client) live in tests/conftest.py — see US#56.
+"""
 
 import uuid
-from collections.abc import AsyncGenerator
-from datetime import UTC, datetime, timedelta
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from httpx import ASGITransport, AsyncClient
-from jose import jwt
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from httpx import AsyncClient
 
-from src.app.config import Settings
-from src.app.database import get_db_session
-from src.app.main import create_app
-from src.app.models.role import Role, UserRole
-from src.app.models.user import Base, User
-
-# Generate a test RSA key pair (once per module)
-_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-TEST_PRIVATE_PEM = _test_private_key.private_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PrivateFormat.PKCS8,
-    encryption_algorithm=serialization.NoEncryption(),
-).decode()
-TEST_PUBLIC_PEM = (
-    _test_private_key.public_key()
-    .public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode()
-)
-
-
-def _make_token(
-    user_id: uuid.UUID,
-    roles: list[str] | None = None,
-    expires_delta: timedelta | None = None,
-) -> str:
-    exp = datetime.now(UTC) + (expires_delta or timedelta(hours=1))
-    payload = {"sub": str(user_id), "exp": exp}
-    if roles:
-        payload["roles"] = roles  # type: ignore[assignment]
-    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
-
-
-@pytest.fixture
-async def db_engine():  # type: ignore[no-untyped-def]
-    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
-
-    # SQLite doesn't enforce foreign keys by default
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def, type-arg]
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-    async with session_factory() as session:
-        yield session
-
-
-@pytest.fixture
-async def seed_roles(db_session: AsyncSession) -> dict[str, Role]:
-    roles = {}
-    for name, desc in [
-        ("admin", "Full platform administration access"),
-        ("researcher", "Access to research tools and datasets"),
-        ("reader", "Read-only access to public content"),
-        ("trial", "Time-limited trial access"),
-    ]:
-        role = Role(name=name, description=desc)
-        db_session.add(role)
-        roles[name] = role
-    await db_session.commit()
-    return roles
-
-
-@pytest.fixture
-async def admin_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
-    user = User(
-        email="admin@test.com",
-        display_name="Admin User",
-        email_verified=True,
-        is_active=True,
-    )
-    db_session.add(user)
-    await db_session.flush()
-
-    user_role = UserRole(
-        user_id=user.id,
-        role_id=seed_roles["admin"].id,
-        granted_by=user.id,
-    )
-    db_session.add(user_role)
-    await db_session.commit()
-    return user
-
-
-@pytest.fixture
-async def regular_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
-    user = User(
-        email="reader@test.com",
-        display_name="Regular User",
-        email_verified=True,
-        is_active=True,
-    )
-    db_session.add(user)
-    await db_session.flush()
-
-    user_role = UserRole(
-        user_id=user.id,
-        role_id=seed_roles["reader"].id,
-    )
-    db_session.add(user_role)
-    await db_session.commit()
-    return user
-
-
-@pytest.fixture
-async def client(
-    db_engine,  # type: ignore[no-untyped-def]
-    db_session: AsyncSession,
-) -> AsyncGenerator[AsyncClient, None]:
-    app = create_app()
-
-    # Override settings — RS256 only, no HS256 fallback
-    def _override_settings() -> Settings:
-        return Settings(
-            JWT_PUBLIC_KEY=TEST_PUBLIC_PEM,
-            DATABASE_URL="sqlite+aiosqlite://",
-        )
-
-    # Override db session to use our test session
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-
-    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
-        async with session_factory() as session:
-            yield session
-
-    from src.app.config import get_settings
-
-    app.dependency_overrides[get_settings] = _override_settings
-    app.dependency_overrides[get_db_session] = _override_db
-
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
-
-
-def _auth_header(user: User) -> dict[str, str]:
-    token = _make_token(user.id)
-    return {"Authorization": f"Bearer {token}"}
+from src.app.models.role import Role
+from src.app.models.user import User
+from tests.conftest import auth_header as _auth_header
 
 
 class TestGetMe:

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,27 +1,23 @@
 """Tests for email verification flow — US #8.
 
-Uses SQLite-backed integration tests matching codebase convention.
+Uses SQLite-backed integration tests matching codebase convention. Shared
+fixtures (RSA keygen, token helpers, db_engine/db_session/client) live in
+tests/conftest.py — see US#56. This module overrides the `settings` fixture
+to add the SMTP + verification config the verification service needs, and
+declares its own `test_user`/`verified_user` (it does not use roles).
 """
 
 from __future__ import annotations
 
-import uuid
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from httpx import ASGITransport, AsyncClient
-from jose import jwt
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.app.config import Settings
-from src.app.database import get_db_session
-from src.app.main import create_app
-from src.app.models.user import Base, User
+from src.app.models.user import User
 from src.app.models.verification_token import TokenType
 from src.app.services.verification import (
     check_rate_limit,
@@ -31,29 +27,15 @@ from src.app.services.verification import (
     invalidate_existing_tokens,
 )
 from src.app.utils.crypto import hash_token
-
-# Generate a test RSA key pair (once per module)
-_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-TEST_PRIVATE_PEM = _test_private_key.private_bytes(
-    encoding=serialization.Encoding.PEM,
-    format=serialization.PrivateFormat.PKCS8,
-    encryption_algorithm=serialization.NoEncryption(),
-).decode()
-TEST_PUBLIC_PEM = (
-    _test_private_key.public_key()
-    .public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode()
-)
+from tests.conftest import TEST_PRIVATE_PEM, build_test_settings
+from tests.conftest import auth_header as _auth_header
 
 
-def _test_settings() -> Settings:
-    return Settings(
-        DATABASE_URL="sqlite+aiosqlite://",
+@pytest.fixture
+def settings() -> Settings:
+    """Override the conftest `settings` fixture with SMTP + verification config."""
+    return build_test_settings(
         JWT_PRIVATE_KEY=TEST_PRIVATE_PEM,
-        JWT_PUBLIC_KEY=TEST_PUBLIC_PEM,
         SMTP_HOST="localhost",
         SMTP_PORT=587,
         SMTP_FROM_EMAIL="test@noorinalabs.com",
@@ -62,46 +44,6 @@ def _test_settings() -> Settings:
         VERIFICATION_RATE_LIMIT_WINDOW_MINUTES=60,
         VERIFICATION_TOKEN_EXPIRE_HOURS=24,
     )
-
-
-def _make_token(user_id: uuid.UUID) -> str:
-    exp = datetime.now(UTC) + timedelta(hours=1)
-    payload = {"sub": str(user_id), "exp": exp, "type": "access"}
-    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
-
-
-def _auth_header(user: User) -> dict[str, str]:
-    token = _make_token(user.id)
-    return {"Authorization": f"Bearer {token}"}
-
-
-@pytest.fixture
-def settings() -> Settings:
-    return _test_settings()
-
-
-@pytest.fixture
-async def db_engine():  # type: ignore[no-untyped-def]
-    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
-
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    yield engine
-    await engine.dispose()
-
-
-@pytest.fixture
-async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def, type-arg]
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-    async with session_factory() as session:
-        yield session
 
 
 @pytest.fixture
@@ -128,30 +70,6 @@ async def verified_user(db_session: AsyncSession) -> User:
     db_session.add(user)
     await db_session.commit()
     return user
-
-
-@pytest.fixture
-async def client(
-    db_engine,  # type: ignore[no-untyped-def]
-    settings: Settings,
-) -> AsyncGenerator[AsyncClient, None]:
-    app = create_app()
-
-    from src.app.config import get_settings
-
-    app.dependency_overrides[get_settings] = lambda: settings
-
-    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
-
-    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
-        async with session_factory() as session:
-            yield session
-
-    app.dependency_overrides[get_db_session] = _override_db
-
-    transport = ASGITransport(app=app)  # type: ignore[arg-type]
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
 
 
 # --- Service-layer integration tests ---


### PR DESCRIPTION
## Summary

Closes #56. Premise verified against wave-10 HEAD (`bd07c19`) — it substantially holds, with three scope adjustments documented below.

### 1. Fixture dedup → `tests/conftest.py`

`test_users_crud.py`, `test_subscriptions.py`, and `test_verification.py` each generated their own 2048-bit RSA key pair, defined identical `_make_token` / `_auth_header` helpers, and rolled their own `db_engine` / `db_session` / `seed_roles` / `admin_user` / `regular_user` / `client` fixture chains — all byte-identical or near-identical.

`conftest.py` now owns:
- the RSA key pair (generated **once per test session** — keygen is the slow part)
- `make_token` / `auth_header` token helpers
- `db_engine` (SQLite + FK pragma) / `db_session` / `seed_roles` / `admin_user` / `regular_user`
- `build_test_settings(**overrides)` + `settings` fixture + `client` fixture
- `client_factory` — caller-supplied settings overrides + optional redis dep
- `FakeRedis` / `FakeRedisPipeline` — previously inline in `test_session_service.py`

The three modules now import from conftest and only declare what is genuinely specific to them (`test_subscriptions` overrides `settings` for the webhook secret; `test_verification` overrides it for SMTP/verification config and keeps its own `test_user`/`verified_user` since it uses no roles). **Behavior-preserving** — all pre-existing tests still pass.

### 2. Missing coverage added

| Area | Where |
|------|-------|
| Session router HTTP endpoints (`POST`/`GET`/`DELETE/{id}`/`DELETE` on `/api/v1/sessions`) — auth gating, status codes, response schemas, round trips | `tests/test_sessions_api.py` (new) |
| `close_redis` (closes client + clears global) + uninitialized-noop guards for both `close_db` and `close_redis` | `test_database_lifecycle.py` |
| `expire_lapsed_subscriptions` — marks active-past-due as expired, leaves active-in-date untouched, no-ops with no subscription | `test_subscriptions.py` |
| OAuth-to-token e2e — chains OAuth callback → issued token → `/auth/token/validate` accepts it | `test_oauth_callback_get.py` (`TestOAuthToTokenFlow`) |

### 3. Scope notes — issue named these, deliberately NOT done

- **"No tests for password-based auth"** — the issue itself says *"there is no password auth implementation."* The `password_hash` column + `UserCreate.password` field exist but no endpoint consumes them. Adding tests for unimplemented behavior is out of scope for a coverage issue — that needs a feature first.
- **"No tests for `close_db`/`close_redis`"** — `close_db` was *already* covered by `test_database_lifecycle.py` (landed via US#107). Only `close_redis` was genuinely missing — added, plus the noop guards.
- **`test_auth_endpoints.py`** was listed as a 4th keygen-dup site; it actually uses empty-key settings (dev-keypair auto-gen), a deliberately different pattern, so it was left as-is rather than force-fit onto the shared keypair fixture.

## Test plan

- [x] `ENVIRONMENT=test uv run pytest` — full suite **276 passed**
- [x] `ENVIRONMENT=test uv run ruff check .` — clean
- [x] `ENVIRONMENT=test uv run ruff format --check tests/` — clean
- [x] `make typecheck` (`mypy src/`) — clean, no issues in 45 files (test-only change, src/ untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
