### PR TITLE
docs(schema): disambiguate the two users→user_roles relations in the ER diagram (#21)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -119,11 +119,11 @@ erDiagram
         timestamptz created_at
     }
 
-    users ||--o{ user_roles : "has roles"
+    users ||--o{ user_roles : "holds role (user_id)"
+    users ||--o{ user_roles : "granted role (granted_by)"
     roles ||--o{ user_roles : "assigned to"
     users ||--o{ sessions : "has sessions"
     users ||--o{ subscriptions : "has subscription"
     users ||--o{ verification_tokens : "has tokens"
     users ||--o{ oauth_accounts : "linked accounts"
-    users ||--o{ user_roles : "grants (granted_by)"
 ```


### PR DESCRIPTION
## Summary

The Mermaid ER diagram in `docs/schema.md` drew **two** `users ||--o{ user_roles` relations:

- `users ||--o{ user_roles : "has roles"` — the `user_id` FK (role membership)
- `users ||--o{ user_roles : "grants (granted_by)"` — the `granted_by` FK (the admin who assigned the role)

Both are genuine FKs from `users` to `user_roles`, but the labels didn't make it clear they map to two **distinct FK columns**, and the two lines weren't adjacent. Mermaid renders multiple relations between the same entity pair as near-overlapping edges, so the diagram read as a duplicate/error rather than an intentional dual relationship.

## Change

Relabel both relations to name the actual FK column each represents, and place them adjacently:

```
users ||--o{ user_roles : "holds role (user_id)"
users ||--o{ user_roles : "granted role (granted_by)"
```

Documentation only — no schema change, no application code touched.

## Test plan

- [x] Diagram validated via Mermaid renderer — `valid: true`, `diagramType: "er"`
- [x] No markdown/mermaid lint in the repo Makefile or CI to run
- [x] Confirmed the two relations correspond to the real FKs: `user_roles.user_id` (composite PK, role membership) and `user_roles.granted_by` (nullable FK, SET NULL on delete) — both documented in the `### user_roles` table section above the diagram

Closes #21
