### PR TITLE
build(docker): add .dockerignore — stop host .venv clobbering builder-stage venv (#79)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,60 @@
+# Python virtual environment — LOAD-BEARING.
+# Without this, `COPY . .` in the runtime stage pulls a host developer's
+# local `.venv/` (from `uv sync`) into the build context and overwrites the
+# builder-stage venv copied via `COPY --from=builder /app/.venv`. The host
+# venv's entry-point scripts (alembic, uvicorn) have shebangs pointing at the
+# developer's absolute host path, so they fail inside the container with
+# `sh: ... not found`. See issue #79.
+.venv/
+venv/
+env/
+
+# Python caches / compiled artefacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+
+# Test / coverage artefacts
+.coverage
+coverage.xml
+htmlcov/
+
+# Git / CI / tooling — not needed in the image, only bloats the build context
+.git/
+.gitignore
+.github/
+.pre-commit-config.yaml
+
+# Local dev compose / docker files — not needed inside the image
+docker-compose.dev.yml
+docker-compose.override.yml
+Dockerfile
+.dockerignore
+
+# Local environment files — never bake secrets into an image
+.env
+.env.*
+!.env.example
+
+# Editor / OS cruft
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Logs / temp
+*.log
+tmp/
+temp/
+.cache/
+
+# Agent / harness workdir — never belongs in a build context
+.claude/


### PR DESCRIPTION
## Summary

The Dockerfile builds in two stages:

```dockerfile
FROM base AS builder
RUN ... uv sync --frozen --no-dev          # produces /app/.venv

FROM base AS runtime
COPY --from=builder /app/.venv /app/.venv  # correct in-container venv
COPY . .                                   # <-- clobbers it with host .venv
```

With **no `.dockerignore`**, `COPY . .` pulls the entire working tree into the build context — including a host developer's local `.venv/` from a prior `uv sync` — and overwrites the builder-stage venv. The host venv's entry-point scripts (`alembic`, `uvicorn`) carry shebangs pointing at the developer's **absolute host path**, so inside the container they fail with `sh: /app/.venv/bin/alembic: not found` and the service crash-loops.

CI and production are immune (fresh clones have no pre-existing `.venv/`), so this only bites local docker builds — e.g. the noorinalabs-deploy integration-test compose building from sibling checkouts. Full root-cause trace in #79.

## Change

Adds a repo-root `.dockerignore`. `.venv/` (plus `venv/`, `env/`) is the **load-bearing** line — it stops the host venv from entering the build context. The rest is build-context hygiene: Python caches, test/coverage artefacts, `.git/`, `.github/`, local compose/docker files, `.env*` (with `!.env.example` re-included so the tracked example file is kept), editor/OS cruft, and `.claude/`.

Checked against the Dockerfile's `COPY` lines — nothing the runtime `COPY . .` needs is excluded: `src/`, `alembic/`, `alembic.ini`, `pyproject.toml`, `uv.lock`, `scripts/`, `tests/`, `Makefile` are all retained.

## Test plan

- [x] Pattern coverage validated against the actual repo tree — every load-bearing exclude (`.venv`, caches, `.git`, `.github`, `.env`, `.claude`, `Dockerfile`, `.dockerignore`) matches; every path the runtime stage needs is kept.
- [x] `!.env.example` ordering confirmed — placed after `.env.*` so Docker's last-match-wins re-includes the tracked example file.
- [x] Rebased onto current wave-10 HEAD before opening (`.dockerignore` is a new file — no conflict surface).
- [ ] **Post-merge:** run the issue's `docker build` reproducer (`uv sync` to create a host `.venv/`, then `docker build` + `docker run ... head -1 /app/.venv/bin/alembic`). **Docker is not available in this dev environment** (WSL integration not enabled), so the live build-verification could not be run here — flagging it as a post-merge check.

Closes #79
