### PR TITLE
tech-debt(lint): annotate SC2209 false-positive on scripts/pre-commit.sh:53 (#102)

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -50,6 +50,7 @@ if [ "${PRE_COMMIT_SKIP_TESTS:-0}" = "1" ]; then
 else
     echo "--- pytest ---"
     if command -v pytest &>/dev/null; then
+        # shellcheck disable=SC2209 # ENVIRONMENT=test is an inline env-var, not a command substitution
         if ! ENVIRONMENT=test pytest --tb=short -q; then
             echo "FAIL: pytest found test failures"
             FAILED=1


### PR DESCRIPTION
## Summary

Closes #102 — `shellcheck` SC2209 warning on `scripts/pre-commit.sh:53`.

The warning is a false positive in spirit: the construct `ENVIRONMENT=test pytest --tb=short -q` is an **inline environment-variable assignment** preceding the `pytest` invocation, not a `var=command` mistake. Rewriting to `var=$(command)` per the SC2209 default suggestion would break env-var semantics — `pytest` would never see `ENVIRONMENT=test`.

Per the issue's secondary acceptance path, applied the explicit-disable-with-rationale annotation so future maintainers understand why the warning is suppressed.

## Diff

```diff
+        # shellcheck disable=SC2209 # ENVIRONMENT=test is an inline env-var, not a command substitution
         if ! ENVIRONMENT=test pytest --tb=short -q; then
```

## Acceptance — verified locally

- [x] `shellcheck scripts/pre-commit.sh` clean (exit 0) — verified with system shellcheck `v0.10.0` per [[feedback_actionlint_needs_shellcheck]]
- [x] `bash scripts/pre-commit.sh` with `PRE_COMMIT_SKIP_TESTS=1` — reaches pytest-skip branch as expected
- [x] `ENVIRONMENT=test bash scripts/pre-commit.sh` with `PRE_COMMIT_SKIP_TESTS=0` — `pytest` executes (proves env-var semantics preserved)
- [x] No other files changed (`git diff --name-only origin/deployments/phase-3/wave-11` returns only `scripts/pre-commit.sh`)

Note: pre-existing mypy errors on `src/app/services/token.py:43,57` (unused `# type: ignore[no-untyped-call]` comments) exist on the wave-11 base — unrelated to this PR, surfaced separately for issue #126. (Prior tracker #76 was closed at p3-wave-10 close without addressing these; #126 is the active tracker.)

## Wave

P3W11 — base `deployments/phase-3/wave-11` @ `76ff877`

## Reviewers

- Primary: @anya-kowalczyk (Tech Lead, user-service)
- Secondary: @aino-virtanen (Standards & Quality Lead, parent org)

## Tech Debt

None introduced. This PR resolves a tech-debt issue without adding new debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
