### PR TITLE
hygiene(gitignore): add .claude/.consulted/ to ignore list (refs noorinalabs-main#465)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ env/
 *.swp
 *.swo
 
+# Claude Code — local-only consultation sentinels
+.claude/.consulted/
+
 # mypy
 .mypy_cache/
 


### PR DESCRIPTION
Refs noorinalabs/noorinalabs-main#465 (parent meta-issue).

## Summary

Add `.claude/.consulted/` to `.gitignore` so consultation sentinels written by `/ontology-librarian` (and future transcript-reading skills under the namespaced sentinel root) don't show as untracked in `git status`.

## Background

The `/ontology-librarian` skill writes a sentinel to `.claude/.consulted/ontology-librarian/<sha1(pwd)[:16]>.marker` on every invocation as part of the Hook 15 (`enforce_librarian_consulted`) fallback path. The #176 namespace migration in `noorinalabs-main` moved the sentinel root from `.claude/.librarian-consulted/` to `.claude/.consulted/<skill_name>/` so multiple transcript-reading hooks could share the same directory without colliding.

That migration updated `noorinalabs-main/.gitignore` but did not sync the change to the 7 child repos. This PR closes the gap in this repo.

## State at origin/main (verified by parent meta-issue)

This repo is one of the 2 **MISSING** repos — neither `.claude/.consulted/` nor the legacy `.claude/.librarian-consulted/` rule is in `.gitignore`. So this PR adds a new `# Claude Code` section with `.claude/.consulted/` only.

## Change

```diff
 # IDE
 .vscode/
 .idea/
 *.swp
 *.swo

+# Claude Code — local-only consultation sentinels
+.claude/.consulted/
+
 # mypy
```

One line in a new logical section (between `# IDE` and `# mypy`).

## Test plan

- [x] Mechanical 1-line `.gitignore` edit; no code touched
- [x] Verify post-merge with: `gh api repos/noorinalabs/noorinalabs-user-service/contents/.gitignore?ref=main --jq '.content' | base64 -d | grep -n '.consulted'` → returns the new rule
- [x] After this lands, `git status` in any worktree of this repo will no longer show `.claude/.consulted/ontology-librarian/<hash>.marker` as untracked

## Tech Debt

None introduced.

## Cross-repo context

Part of the 7-PR sweep tracked in `noorinalabs/noorinalabs-main#465`. The 6 sibling PRs follow the same shape. Reviewers (Aino Virtanen + Santiago Ferreira, parent-side org-level) approved a one-time charter carve-out from `feedback_child_repo_implementer_rule` for this mechanical cross-repo cleanup because the rule being inherited (`.claude/.consulted/`) was authored parent-side.
