### PR TITLE
feat(api): publish canonical RoleName enum in UserRead schema (#103)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim AS base
+# python:3.12-slim digest-pinned for reproducible builds + trivy-stable OS package
+# baseline. Re-pin to a fresh digest when OS CVEs accumulate (target cadence: monthly
+# or when CI surfaces failures). Last pin: 2026-05-19.
+FROM python:3.12-slim@sha256:bf73779de6dbd030f3d189eeeb246286965832761ace318c1518300f76c0840d AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \

--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -150,6 +150,17 @@
         "title": "RoleAssignment",
         "type": "object"
       },
+      "RoleName": {
+        "description": "Canonical role names exposed in the public API.\n\nSource of truth: `role_hierarchy` in `ontology/repos/user-service.yaml`\nand the seed data created by migration 0001. Renames or additions must\ngo through cross-repo coordination (us#103, main#161).",
+        "enum": [
+          "admin",
+          "researcher",
+          "reader",
+          "trial"
+        ],
+        "title": "RoleName",
+        "type": "string"
+      },
       "RoleRead": {
         "properties": {
           "created_at": {
@@ -697,7 +708,7 @@
           },
           "roles": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/RoleName"
             },
             "title": "Roles",
             "type": "array"

--- a/src/app/schemas/user.py
+++ b/src/app/schemas/user.py
@@ -1,7 +1,22 @@
 import uuid
 from datetime import datetime
+from enum import StrEnum
 
 from pydantic import BaseModel, EmailStr, Field
+
+
+class RoleName(StrEnum):
+    """Canonical role names exposed in the public API.
+
+    Source of truth: `role_hierarchy` in `ontology/repos/user-service.yaml`
+    and the seed data created by migration 0001. Renames or additions must
+    go through cross-repo coordination (us#103, main#161).
+    """
+
+    admin = "admin"
+    researcher = "researcher"
+    reader = "reader"
+    trial = "trial"
 
 
 class UserBase(BaseModel):
@@ -20,7 +35,7 @@ class UserRead(UserBase):
     locale: str | None
     is_active: bool
     created_at: datetime
-    roles: list[str] = Field(default_factory=list)
+    roles: list[RoleName] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## Summary

Closes #103. Publishes the canonical role-name vocabulary as a typed OpenAPI component so downstream consumers can codegen against a checked enum instead of a free-form `list[str]`.

## What landed

- New `RoleName` StrEnum in `src/app/schemas/user.py` with the 4 canonical values from `ontology/repos/user-service.yaml:69`: `admin`, `researcher`, `reader`, `trial`.
- `UserRead.roles` changed from `list[str]` to `list[RoleName]`.
- Regenerated `docs/openapi-snapshot.json` — `RoleName` now appears under `components.schemas` and `UserRead.roles.items` `$ref`s it.

## Scope expansion: digest-pin python:3.12-slim base image

A second commit on this PR digest-pins the `python:3.12-slim` base image in `Dockerfile`:

```
FROM python:3.12-slim@sha256:bf73779de6dbd030f3d189eeeb246286965832761ace318c1518300f76c0840d AS base
```

**Why bundled into this PR**: post-rebase, the `build-and-push` trivy gate started flagging 3 NEW OS-level HIGH CVEs in the `python:3.12-slim` floating tag (libcap2 + 2 others) — orthogonal state-of-world drift surfaced in `python:3.12-slim` between wave-10 and wave-11. Owner-approved scope expansion under single-purpose discipline: the PR cannot merge without the base-image change, so it's infrastructure-needed-to-land-the-feature rather than scope-creep. python:3.14-slim is not an option per the failed attempt in PR #41 (dep breakage).

**Why digest-pin rather than `apt-get upgrade -y`**: digest-pinning is deterministic and reviewable — you can audit exactly what's in the image from the Dockerfile alone. `apt-get upgrade -y` would introduce build-time non-determinism (different layers on different days). Aligns with the SHA-pinning pattern Aino flagged in her us#123 review where GitHub Actions are SHA-pinned in `ghcr-publish.yml`.

**Re-pin cadence**: a comment above the FROM line documents the pin date (2026-05-19) and target cadence (monthly, or when CI surfaces failures). Future Dependabot / digest-rebump automation is a W12 cross-repo candidate (this Dockerfile pattern should propagate to every child repo building Docker images) — not in scope here.

## Naming decision: `RoleName`, not `UserRole`

The issue body proposed the name `UserRole`. That name is already taken by the SQLAlchemy join-table model at `src/app/models/role.py:27` (the `user_roles` table). Using `UserRole` in `src/app/schemas/user.py` would shadow imports in any module pulling both — `src/app/services/rbac.py` and `src/app/services/user.py` both import the ORM `UserRole` today. `RoleName` is the cleaner name and semantically equivalent for the issue's intent ("publish canonical role names"). Happy to revisit on review if reviewers prefer a different name.

## Scope kept tight (schema)

`TokenValidationResponse.roles` in `src/app/schemas/auth.py:54` is also `list[str]` and is a similar candidate for the same treatment. Left unchanged here to keep the PR to the one schema us#103 calls out; can file a follow-up if reviewers want it included in the same wave.

## Verification

- `uv run ruff check src/app/schemas/user.py` — clean
- `uv run ruff format --check src/app/schemas/user.py` — clean
- `uv run mypy src/app/schemas/user.py` — no issues
- `ENVIRONMENT=test uv run pytest --tb=short -q` — 247 passed, 1 unrelated deprecation warning (re-verified post-rebase onto wave-11 head 5ed0488 incl. us#128 dep bumps)
- `make openapi-snapshot && git diff --exit-code docs/openapi-snapshot.json` — drift gate passes after regeneration (verifies us#123's drift gate is satisfied)
- Snapshot includes `"RoleName"` component schema with the 4 canonical enum values and `UserRead.roles.items.$ref = #/components/schemas/RoleName`
- Digest verification: `python:3.12-slim` linux/amd64 manifest digest `sha256:bf73779de6dbd030f3d189eeeb246286965832761ace318c1518300f76c0840d` fetched from Docker Hub registry API (2026-05-19)

## Cross-references

- Parent meta-issue: noorinalabs/noorinalabs-main#161
- Sibling consumer-side: noorinalabs/noorinalabs-isnad-graph (frontend union audit, tracked separately per us#103 cross-refs section)
- Coupled with main#160 (OpenAPI codegen — once that lands, this enum becomes consumer-checkable at compile time)
- Uses the drift gate from #123 (merged into wave-11)
- Unblocked-by: us#128 (Mako/python-multipart CVE bumps, merge sha `5ed0488`)
- Future cross-repo work: propagate Dockerfile digest-pin pattern to all child repos building Docker images (file in W12 planning)

## Wave

P3W11 — base `deployments/phase-3/wave-11` @ `5ed0488` (post-us#128 rebase; us#128 cherry-picked us#111 onto wave-11 to unblock the trivy CVE gate)

## Hook 4 reviewer note

Existing 2-Approved reviews from prior commit `297bd56` stand against the structure of this PR; scope expansion to Dockerfile digest-pin is documented here for transparency in case reviewers want to re-check. The change is small (one FROM line + 3 lines of comment) and confined to base-image infrastructure.

Requestor: Anya Kowalczyk
Requestee: TBD
RequestOrReplied: New
TechDebt: none
