### PR TITLE
ci: bump Node-20 actions to Node-24 (#132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --extra dev
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -22,8 +22,8 @@ jobs:
   openapi-snapshot-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --extra dev
       - name: Regenerate snapshot
         run: make openapi-snapshot

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -46,20 +46,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
         # Skipped on pull_request — PR runs do not push, so no registry creds
         # are exposed to PR-context jobs (which run with read-only GITHUB_TOKEN
         # for forks anyway, but keeping the step gated is defence-in-depth).
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Tag scheme (isnad-graph#815 Contract v6 = option C, 2026-04-23):
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           # PRs build single-arch (amd64) and load into the local Docker daemon
@@ -190,7 +190,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Trigger deploy repo
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.DEPLOY_REPO_PAT }}
           repository: noorinalabs/noorinalabs-deploy


### PR DESCRIPTION
## Summary

GitHub forces all actions onto Node.js 24 on **2026-06-02**; the Node-20 actions in our two workflows are deprecated and may break after that date. This bumps every affected action to a Node-24 major.

### `.github/workflows/ci.yml` (tag-pinned)
- `actions/checkout` v4 → v6 (2 occurrences)
- `astral-sh/setup-uv` v5 → v7 (2 occurrences)

### `.github/workflows/ghcr-publish.yml` (SHA-pinned — hardening preserved)
Re-pinned to each new major's **current commit SHA** (not switched to floating tags), with an accurate version comment:

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `11bd7190` v4.2.2 | `de0fac2e` v6.0.2 |
| `docker/setup-qemu-action` | `29109295` v3.6.0 | `06116385` v4.1.0 |
| `docker/setup-buildx-action` | `b5ca5143` v3.10.0 | `d7f5e7f5` v4.1.0 |
| `docker/login-action` | `74a5d142` v3.4.0 | `650006c6` v4.2.0 |
| `docker/metadata-action` | `902fa8ec` v5.7.0 | `80c7e94d` v6.1.0 |
| `docker/build-push-action` | `14487ce6` v6.16.0 | `f9f3042f` v7.2.0 |
| `peter-evans/repository-dispatch` | v3 | v4 (tag-pinned) |

All target majors are confirmed Node-24. `actionlint` (with shellcheck) clean.

Closes #132
Refs noorinalabs/noorinalabs-main#536

TechDebt: none