### PR TITLE
security: bump starlette to 1.0.1 — PYSEC-2026-161 (#134)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ description = "User authentication, authorization, and profile management for No
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.32.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "alembic>=1.14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -707,6 +707,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -747,6 +748,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "types-pyasn1", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "types-python-jose", marker = "extra == 'dev'", specifier = ">=3.3.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
@@ -1164,15 +1166,15 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

[PYSEC-2026-161](https://osv.dev/vulnerability/PYSEC-2026-161) is a **starlette Host-header auth-bypass** — missing Host header validation lets an attacker inject paths into reconstructed URLs, potentially bypassing path-based auth checks. It affects all starlette versions through **1.0.0** and is fixed in **1.0.1**.

user-service had starlette locked transitively (via fastapi 0.135.3) at **1.0.0** — in the affected range. This was latent because user-service has no pip-audit/security-audit CI gate.

## Change

- Added an explicit `starlette>=1.0.1` floor to `pyproject.toml` (it was previously transitive-only).
- Re-locked with `uv lock`. uv resolves starlette to **1.2.0** — above the patched 1.0.1 floor.
- No fastapi change needed: fastapi 0.135.3 already supports starlette 1.x.

## Verification (manual — no pip-audit gate in this repo)

- `uv.lock` now resolves `starlette 1.2.0` (was `1.0.0`).
- Full test suite: **247 passed** (`ENVIRONMENT=test uv run pytest`).
- One pre-existing deprecation warning (`HTTP_422_UNPROCESSABLE_ENTITY` in `src/app/routers/subscriptions.py:145`) is surfaced by the bump but is unrelated to it and out of scope.

Closes #134

TechDebt: none