### PR TITLE
tech-debt(mypy): remove unused type-ignore comments in token.py (Refs #126)

### DIFF
--- a/src/app/services/token.py
+++ b/src/app/services/token.py
@@ -40,9 +40,7 @@ def create_access_token(
         "type": "access",
     }
     private_key = get_private_key(settings)
-    token: str = jwt.encode(  # type: ignore[no-untyped-call]
-        payload, private_key, algorithm=settings.JWT_ALGORITHM
-    )
+    token: str = jwt.encode(payload, private_key, algorithm=settings.JWT_ALGORITHM)
     return token, expires_at
 
 
@@ -54,7 +52,7 @@ def create_refresh_token() -> str:
 def decode_access_token(settings: Settings, token: str) -> dict[str, Any]:
     """Decode and validate an access token. Raises JWTError on failure."""
     public_key = get_public_key(settings)
-    payload: dict[str, Any] = jwt.decode(  # type: ignore[no-untyped-call]
+    payload: dict[str, Any] = jwt.decode(
         token,
         public_key,
         algorithms=[settings.JWT_ALGORITHM],


### PR DESCRIPTION
## Summary

Removes the two `# type: ignore[no-untyped-call]` comments on the `jwt.encode` (line 43) and `jwt.decode` (line 57) calls in `src/app/services/token.py`. The currently-pinned `python-jose` stubs expose typed signatures, so mypy strict reports both ignores as `[unused-ignore]`.

The unrelated `# type: ignore[assignment]` on the `revoke_refresh_token` `CursorResult` assignment is **load-bearing** and left in place (verified: mypy reports no error for it).

## Verification
- `uv run mypy src/` → Success: no issues found in 44 source files (the 2 `[unused-ignore]` errors are gone)
- `uv run ruff check` / `ruff format --check` → clean
- `ENVIRONMENT=test uv run pytest -q` → 247 passed

## TechDebt
None added. Net-negative — removes 2 stale suppressions.

Re-surfaced post-#76 (closed without addressing at p3-wave-10 close).

Refs #126