### PR TITLE
tech-debt(metrics): expose Prometheus /metrics endpoint (Refs #124)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aiosmtplib>=3.0.0",
     "pyotp>=2.9.0",
     "cryptography>=43.0.0",
+    "prometheus-fastapi-instrumentator>=7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -52,9 +52,19 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Prometheus instrumentation. Default-config exporter labels each series by
     # handler (route template) + method + status — all low-cardinality, no
-    # per-user/per-session labels. The /metrics endpoint is excluded from the
-    # OpenAPI schema and is only reachable on the backend Docker network where
-    # Prometheus scrapes it; Caddy does not proxy /metrics publicly (deploy#64).
+    # per-user/per-session labels. The endpoint is excluded from the OpenAPI
+    # schema so it does not leak into the public API surface.
+    #
+    # SECURITY — public exposure is gated in the deploy layer, NOT here. The app
+    # serves /metrics on every interface it listens on; the user-service vhost
+    # users.{base} in noorinalabs-deploy/caddy/Caddyfile ends with a catch-all
+    # `handle { reverse_proxy user-service:8000 }`, so WITHOUT an explicit block
+    # an inbound https://users.{base}/metrics would be publicly reachable. The
+    # required guard is a `handle /metrics { respond 403 }` on the users.{base}
+    # vhost, tracked as a HARD prod-deploy prerequisite in noorinalabs-deploy#386
+    # (Idris Yusuf review catch on PR #137). Prometheus itself scrapes
+    # user-service:8000/metrics over the backend Docker network, which the Caddy
+    # 403 does not affect.
     Instrumentator().instrument(application).expose(
         application, endpoint="/metrics", include_in_schema=False
     )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from src.app.config import Settings, get_settings
 from src.app.database import close_db, close_redis, init_db, init_redis
@@ -48,6 +49,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     add_cors_middleware(application)
     add_security_headers(application)
+
+    # Prometheus instrumentation. Default-config exporter labels each series by
+    # handler (route template) + method + status — all low-cardinality, no
+    # per-user/per-session labels. The /metrics endpoint is excluded from the
+    # OpenAPI schema and is only reachable on the backend Docker network where
+    # Prometheus scrapes it; Caddy does not proxy /metrics publicly (deploy#64).
+    Instrumentator().instrument(application).expose(
+        application, endpoint="/metrics", include_in_schema=False
+    )
 
     application.include_router(health.router)
     application.include_router(auth.router)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,37 @@
+"""Tests for the Prometheus /metrics endpoint.
+
+The endpoint is exposed by prometheus_fastapi_instrumentator and scraped by
+Prometheus over the backend Docker network (deploy#64). It must respond 200
+with the Prometheus text exposition format and emit the default
+`http_requests_total` counter once at least one request has been handled.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_prometheus_exposition(client: AsyncClient) -> None:
+    # Drive one request through the instrumented middleware so the default
+    # http_requests_total counter has at least one observed series to expose.
+    health = await client.get("/health")
+    assert health.status_code == 200
+
+    response = await client.get("/metrics")
+    assert response.status_code == 200
+
+    content_type = response.headers["content-type"]
+    assert content_type.startswith("text/plain"), content_type
+
+    body = response.text
+    assert "http_requests_total" in body
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_excluded_from_openapi_schema(client: AsyncClient) -> None:
+    # include_in_schema=False — /metrics must not leak into the public OpenAPI spec.
+    spec = await client.get("/openapi.json")
+    assert spec.status_code == 200
+    assert "/metrics" not in spec.json()["paths"]

--- a/uv.lock
+++ b/uv.lock
@@ -700,6 +700,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "passlib", extra = ["bcrypt"] },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pyotp" },
@@ -738,6 +739,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "neo4j", marker = "extra == 'dev'", specifier = ">=6.1.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
@@ -794,6 +796,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411, upload-time = "2026-05-29T13:04:44.17Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Prometheus instrumentation to user-service so it can be scraped by Prometheus over the backend Docker network. Carved out of deploy#64's `user-service:8000` scrape AC ([[feedback_runtime_gate_scoping]] — the deploy-side scrape was blocked on this endpoint existing).

## Changes
- **`pyproject.toml`**: add `prometheus-fastapi-instrumentator>=7.0.0` (resolves to 8.0.0; + `uv.lock`).
- **`src/app/main.py`**: after `add_security_headers()`, `Instrumentator().instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)`. Default-config exporter → low cardinality (handler + method + status; no per-user/session labels).
- **`tests/test_metrics.py`**: asserts `/metrics` → 200 + `text/plain` content-type with an `http_requests_total` line, and that `/metrics` is excluded from the OpenAPI schema.

## Security — public exposure is gated in the deploy layer (CORRECTED)

> **Correction.** An earlier revision of this PR claimed `/metrics` was already non-public because `noorinalabs-deploy/caddy/Caddyfile` has `handle /metrics { respond 403 }`. **That was wrong** — Idris Yusuf's review caught it. The 403 block is on the **`isnad.{base}`** vhost (which fronts isnad-graph). The user-service vhost **`users.{base}`** ends with a catch-all `handle { reverse_proxy user-service:8000 }` and has **no** `/metrics` handler — so once this ships, `https://users.{base}/metrics` would be **publicly reachable**.

The application code in this PR is correct and unchanged: the endpoint must exist for Prometheus to scrape it over the backend Docker network. Public exposure is gated in the **deploy layer, not here**.

**Hard prod-deploy prerequisite:** noorinalabs-deploy#386 — add `handle /metrics { respond 403 }` to the `users.{base}` vhost. This PR MUST NOT be deployed to prod ahead of deploy#386 landing, or `/metrics` is publicly exposed on `users.{base}`. The `main.py` comment documents this dependency inline. Prometheus's backend-network scrape of `user-service:8000/metrics` is unaffected by the Caddy 403 (it bypasses the public vhost).

## Verification
- `ENVIRONMENT=test uv run pytest -q` → **249 passed** (247 baseline + 2 new)
- `uv run ruff check .` / `ruff format --check .` → clean
- mypy clean on `main.py` (the 2 pre-existing `token.py` `[unused-ignore]` errors are out of scope; handled by PR #136 / #124's sibling #126). Note: CI runs ruff + pytest, not mypy.

## Deploy follow-ups
- **noorinalabs-deploy#386** (Nurul Hakim / Nino) — `handle /metrics { respond 403 }` on `users.{base}` vhost. **Hard prerequisite for prod deploy** (see Security section).
- AC item 5: noorinalabs-deploy to add the `user-service:8000/metrics` scrape to `infra/prometheus/prometheus.{stg,prod}.yml` in a follow-up PR.

## TechDebt
None added.

Refs #124
