### PR TITLE
tech-debt(ci/docker): Dockerfile hardening — digest pin + trivy allowlist (Refs #129)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot — Docker base-image digest monitoring (us#129).
+#
+# Watches the Dockerfile at the repo root and opens auto-PRs when a fresher
+# python:3.12-slim manifest-list digest is available, so re-pinning the base
+# image (see the Dockerfile re-pin cadence comment) is a regular, reviewed event
+# rather than a CI-failure-triggered emergency. Mirrors the deploy repo's
+# package-ecosystem: docker convention (commit prefix + tech-debt/ci-cd labels).
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - tech-debt
+      - ci-cd
+      - "deps:docker"
+    commit-message:
+      prefix: "deps(docker)"

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -151,6 +151,11 @@ jobs:
           exit-code: "1"
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          # Per-CVE allowlist with documented rationale + auto-expiry (us#129).
+          # The file ships empty: OS CVEs are addressed by the Dockerfile digest
+          # pin, not suppression, so the gate stays fully active until a CVE is
+          # explicitly justified there.
+          trivyignores: .trivyignore
 
       - name: Summary
         if: always()

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,39 @@
+# .trivyignore — Trivy CVE allowlist for noorinalabs-user-service
+#
+# Wired into the Trivy scan via `trivyignores: .trivyignore` in
+# .github/workflows/ghcr-publish.yml. The scan still blocks the merge on any
+# CRITICAL/HIGH, fixed CVE that is NOT listed here (exit-code: 1,
+# ignore-unfixed: true), so this file is the ONLY suppression surface — keep it
+# minimal and audited.
+#
+# WHEN TO ADD AN ENTRY
+# Only for a genuinely-unexploitable CVE in our runtime context, AND only when a
+# fresh base-image digest pin (see Dockerfile re-pin cadence) cannot satisfy it
+# because the fix is not yet backported to our Debian base. Prefer re-pinning or
+# the Trixie base switch (us#129) over suppression whenever a fix exists.
+#
+# EVERY ENTRY MUST DOCUMENT (per the block template below):
+#   1. CVE id + the affected package, on its own comment line
+#   2. WHY it is not exploitable in OUR runtime (specific to the package + how we
+#      use it — generic "low severity" is not a rationale)
+#   3. A re-evaluation TRIGGER (e.g. "when Debian Bookworm backports the fix")
+#   4. An auto-EXPIRY date (3-month cadence per ops convention) — on expiry the
+#      gate fires again and forces a re-justification. Trivy does not enforce the
+#      date itself; it is a human/review tripwire. A periodic audit (or the
+#      Dependabot-driven re-pin review) prunes expired entries.
+#
+# TEMPLATE (copy, fill in, uncomment):
+#   # CVE-YYYY-NNNNN (<package> — <one-line CVE description>)
+#   # Not exploitable: <runtime-specific rationale>.
+#   # Re-evaluate: <trigger>.
+#   # Filed YYYY-MM-DD, expires YYYY-MM-DD.
+#   CVE-YYYY-NNNNN
+#
+# ---------------------------------------------------------------------------
+# Active allowlist entries: NONE.
+#
+# The us#127 round-2 OS CVEs (libcap2 / libsystemd0 in python:3.12-slim) are
+# addressed structurally by the fresh digest pin in the Dockerfile rather than
+# suppressed here, so the gate stays fully active. Add an entry ONLY if a future
+# scan surfaces a CVE that a fresh digest pin demonstrably cannot fix and the
+# package is genuinely outside our attack surface — with full rationale above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,25 @@
 # syntax=docker/dockerfile:1
-FROM python:3.12-slim AS base
+
+# Base image digest-pinned for reproducible builds + a trivy-stable OS-package
+# baseline (issue us#129). The pinned digest is the multi-arch python:3.12-slim
+# manifest-list index — it resolves linux/amd64 + linux/arm64, so the digest pin
+# does NOT regress the multi-arch push build (ghcr-publish.yml builds amd64+arm64
+# on push, amd64-only on PR for the Trivy scan).
+#
+# Re-pin cadence: monthly, OR whenever CI's Trivy gate surfaces OS-level CVE
+# failures the current pin can't satisfy. Dependabot (.github/dependabot.yml)
+# opens auto-PRs for fresher digests so re-pinning is an intentional, reviewed
+# event rather than a CI-failure-triggered emergency.
+#
+# Base-image upgrade path: when python:3.12-slim-trixie (Debian 13 / Trixie)
+# tags stabilize, evaluate switching — Trixie carries the +deb13u1 OS fixes that
+# Bookworm only backports later, the structural source of the recurring libcap2 /
+# libsystemd0 Trivy failures (us#127 round 2). Do NOT bump unilaterally: test
+# dependency compatibility first (cf. PR #41 "3.14 breaks deps"), land the base
+# switch in its own PR, and drop any then-redundant .trivyignore entries.
+#
+# Last pin: 2026-05-31 (digest resolved from Docker Hub at PR-open time).
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \


### PR DESCRIPTION
## What

Dockerfile / CI hardening for `noorinalabs-user-service` to stop the recurring, content-orthogonal Trivy failures (us#127 deferral chain — CVE DB updates faster than the base image / lockfile).

### Changes
- **Dockerfile** — pin `python:3.12-slim` by the multi-arch **manifest-list digest** `sha256:090ba77e…fe203` (resolved from Docker Hub at PR-open time, 2026-05-31). The digest is an OCI **index** covering `linux/amd64` + `linux/arm64`, so the pin does **not** regress the multi-arch push build (`ghcr-publish.yml` builds amd64+arm64 on push, amd64-only on PR). Adds a documented **re-pin cadence** and an explicit **base-image upgrade path** (→ `python:3.12-slim-trixie` / Debian 13 `+deb13u1`, in its own PR after dep-compat testing).
- **`.trivyignore`** — establishes the per-CVE allowlist mechanism with a mandatory template: rationale (why unexploitable in *our* runtime) + re-eval trigger + **3-month auto-expiry**. Ships **empty** — OS CVEs are addressed structurally by the fresh digest pin, not suppression, so the gate stays fully active.
- **`ghcr-publish.yml`** — wires `trivyignores: .trivyignore` into the existing Trivy step (still `exit-code: 1`, `severity: CRITICAL,HIGH`, `ignore-unfixed: true`).
- **`.github/dependabot.yml`** — weekly Docker base-image digest monitoring (mirrors deploy-repo convention), making re-pinning an intentional, reviewed event rather than a CI-failure emergency. New `deps:docker` label created in the repo.

## Acceptance-criteria coverage (#129)
- [x] All `FROM` lines digest-pinned + re-pin cadence comment
- [x] `.trivyignore` with per-CVE rationale + auto-expiry template (mechanism wired, ships empty)
- [x] Dependabot config monitoring base-image digests
- [ ] **CI passes consistently across a 1-week observation window** — runtime-gated; cannot be demonstrated at PR time (see below)
- [ ] **us#103 UserRole absorption** — explicitly out of scope here; tracked separately (see Out-of-scope)
- [x] PR documents runtime-acceptance vs PR-time-acceptance trade-off (this section)

## PR-time vs runtime acceptance
Per `feedback_pr_vs_runtime_acceptance_criteria`: the unit-mechanic correctness is delivered and verifiable now (digest resolves to a valid amd64+arm64 index, `trivyignores` wired, dependabot/workflow YAML valid). The **1-week no-flake observation** is a runtime property that can only be confirmed post-merge by watching the Trivy gate over time — it is **not** a PR-time gate. Recommend a post-merge tracking item on #129 to confirm the observation window.

## Out of scope (separate issues per #129 §3/§5)
- Cross-repo propagation of the hardening pattern to `isnad-graph` / `deploy` / `ingest-platform` / `data-acquisition` — file a cross-repo coordination issue in `noorinalabs-main`.
- `us#103` UserRole-enum absorption onto a fresh base + merge.
- Base switch to Trixie (separate PR after dep-compat testing).

## Validation
- `actionlint` clean (shellcheck on PATH).
- `ruff check` + `ruff format --check` clean; **247 tests pass** (`ENVIRONMENT=test`).
- Digest validity (multi-arch index, amd64+arm64) confirmed out-of-band via the Docker Hub registry API.
- **Local docker build runtime-gated** — Docker daemon unreachable in the dev sandbox; the digest-pin resolution will be exercised by the PR's `Publish to GHCR` workflow (single-arch amd64 build + Trivy scan).

Refs #129
