### PR TITLE
ci(docs): align user-service docs-CI to canonical full set + actionlint mirror (Refs #326 #327)

### DIFF
--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -138,21 +138,25 @@ class DriftDirection(unittest.TestCase):
 
 
 class ThisRepoHasNoDrift(unittest.TestCase):
-    """The user-service config must mirror its ci.yml kinds — this is the gate
-    running against the very repo that ships it. Scoped to ci.yml only; docs.yml
-    gates a different artifact class (markdown/config/actionlint) that
-    pre-commit intentionally does not mirror."""
+    """The user-service config must mirror its QUALITY-GATE CI kinds — this is the
+    gate running against the very repo that ships it. Scoped to the two PR-gate
+    workflows (ci.yml code + docs.yml markdown/config/actionlint); the actionlint
+    pre-commit hook covers docs.yml's actionlint kind. ghcr-publish.yml is
+    excluded — its `docker build` is a release-time publish, not a local
+    fast-feedback check pre-commit should mirror."""
 
-    def test_precommit_mirrors_ci(self) -> None:
+    def test_precommit_mirrors_quality_gate_ci(self) -> None:
         precommit = _REPO_ROOT / ".pre-commit-config.yaml"
         ci = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+        docs = _REPO_ROOT / ".github" / "workflows" / "docs.yml"
         self.assertTrue(precommit.is_file(), "repo must have a pre-commit config")
         self.assertTrue(ci.is_file(), "repo must have ci.yml")
-        harmful, _ = check_repo(precommit, [ci])
+        self.assertTrue(docs.is_file(), "repo must have docs.yml")
+        harmful, _ = check_repo(precommit, [ci, docs])
         self.assertEqual(
             harmful,
             set(),
-            f"pre-commit must mirror ci.yml; missing locally: {sorted(harmful)}",
+            f"pre-commit must mirror the quality-gate CI; missing locally: {sorted(harmful)}",
         )
 
 

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "//": "Spellcheck for noorinalabs-user-service authored docs (#326). Scoped to the authored prose set (CLAUDE.md, the ADR/schema docs, the team charter). Roster cards + the append-only feedback_log are excluded — they are dense with person names and SHAs that would balloon the dictionary without catching real typos. Domain vocabulary lives in project-words.txt.",
+  "dictionaryDefinitions": [
+    {
+      "name": "project-words",
+      "path": "./.cspell/project-words.txt",
+      "addWords": true
+    }
+  ],
+  "dictionaries": ["project-words", "en_US", "softwareTerms", "bash", "python", "node", "filetypes"],
+  "ignoreRegExpList": [
+    "/[0-9a-f]{7,40}/",
+    "/https?:\\/\\/[^\\s)]+/",
+    "/`[^`]+`/",
+    "/<!--[\\s\\S]*?-->/",
+    "/\\b[A-Z_]{3,}\\b/"
+  ],
+  "files": [
+    "CLAUDE.md",
+    "docs/**/*.md",
+    ".claude/team/charter.md"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    ".venv/**",
+    ".claude/worktrees/**"
+  ]
+}

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,0 +1,22 @@
+# Project words for noorinalabs-user-service docs spellcheck (#326).
+# Domain vocabulary, product/library names, and team-member names that appear in
+# authored prose (CLAUDE.md, docs/, the team charter) and are not spelling
+# defects. Add new domain terms here rather than suppressing the cspell job.
+
+# Org / product
+Noorin
+noorinalabs
+isnad
+
+# Tooling / libraries
+joserfc
+worktree
+Worktrees
+
+# Team-member names (appear in the charter / roster references)
+Anya
+Boukhari
+Idris
+Kowalczyk
+Mateo
+Yusuf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,15 @@ jobs:
         with:
           python-version: "3.12"
       - name: Verify pre-commit config mirrors CI-enforced checks (#327)
-        # Fails if a check the code-CI workflow enforces (ruff/mypy/pytest/…) is
-        # missing from .pre-commit-config.yaml, so local hooks can't silently
-        # drift behind CI. Scoped to THIS workflow (ci.yml) only — docs.yml gates
-        # a different artifact class (markdown/config/actionlint) that pre-commit
-        # intentionally does not mirror, so it is excluded from the comparison.
-        run: python3 .claude/lib/pre_commit_ci_sync.py . --ci .github/workflows/ci.yml
+        # Fails if a check the QUALITY-GATE CI workflows enforce
+        # (ruff/mypy/pytest/actionlint/…) is missing from .pre-commit-config.yaml,
+        # so local hooks can't silently drift behind CI. Scans BOTH PR-gate
+        # workflows — ci.yml (code) AND docs.yml (markdown/config/actionlint) —
+        # per the canonical org direction (parent #571/#572): docs.yml's
+        # actionlint job is mirrored by the actionlint pre-commit hook, so the
+        # gate stays green. ghcr-publish.yml is EXCLUDED: it is a release-time
+        # container build/push (its `docker build` is not a local fast-feedback
+        # check pre-commit should mirror), unlike the parent/landing repos whose
+        # only workflows are quality gates. This is the user-service-specific
+        # deviation from a bare unscoped `.` invocation.
+        run: python3 .claude/lib/pre_commit_ci_sync.py . --ci .github/workflows/ci.yml --ci .github/workflows/docs.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,18 +2,13 @@ name: CI — Docs & Config
 
 # Phase-3 end-state criterion #5 (noorinalabs-main#326): all committed artifacts
 # pass checks — including documentation and config, not just the Python that
-# ci.yml gates. This workflow closes the NON-python gap for user-service:
-# markdown lint over committed docs, committed-config syntax (YAML/JSON parse),
-# and workflow actionlint. Adapted from the parent-canonical docs.yml; scoped to
-# this repo's actual surface (docs/, CLAUDE.md, .claude/team, alembic migration
-# notes, the root config files).
-#
-# Spellcheck (cspell) + internal link-check (lychee) — present in the parent —
-# are intentionally deferred for this repo's pilot: they add a project-words
-# dictionary + lychee-config maintenance tax that is out of proportion to this
-# repo's small prose corpus, and the markdown/config/actionlint gates already
-# cover the structural-breakage class. Adding them is a tracked follow-up, not a
-# blocker for the rollout.
+# ci.yml gates. This workflow closes the NON-python gap for user-service with the
+# org-canonical FULL docs-CI set (ratified by the owner after the #141 pilot):
+# markdown lint, spellcheck (cspell), internal link-check (lychee), committed-
+# config syntax (YAML/JSON parse), and workflow actionlint over this repo's
+# committed docs/config (docs/, CLAUDE.md, .claude/team, alembic migration notes,
+# the root config files). Adapted from the parent-canonical docs.yml + the
+# landing-page pilot's cspell/lychee shape.
 
 on:
   push:
@@ -22,8 +17,13 @@ on:
       - "**/*.md"
       - "**/*.yaml"
       - "**/*.yml"
+      - "**/*.json"
+      - "**/*.jsonc"
       - ".claude/team/**"
       - ".markdownlint-cli2.jsonc"
+      - ".cspell.json"
+      - ".cspell/**"
+      - ".lychee.toml"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [main, "deployments/**"]
@@ -31,8 +31,13 @@ on:
       - "**/*.md"
       - "**/*.yaml"
       - "**/*.yml"
+      - "**/*.json"
+      - "**/*.jsonc"
       - ".claude/team/**"
       - ".markdownlint-cli2.jsonc"
+      - ".cspell.json"
+      - ".cspell/**"
+      - ".lychee.toml"
       - ".github/workflows/docs.yml"
 
 permissions:
@@ -43,18 +48,56 @@ jobs:
     name: Markdown lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: markdownlint-cli2
         # Config (.markdownlint-cli2.jsonc) carries the glob + ignores and
         # disables the stylistic rules the docs corpus intentionally uses,
         # keeping the structural rules that catch real breakage.
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
 
+  spellcheck:
+    name: Spellcheck (cspell)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
+        with:
+          # Dictionary + ignore rules come from .cspell.json. The `files` glob
+          # here is authoritative for the action; it is scoped to the AUTHORED
+          # prose set — CLAUDE.md, the ADR/schema docs, the team charter. The
+          # roster cards + append-only feedback_log are excluded: they are dense
+          # with person names that are not spell-defects. A real typo in authored
+          # prose blocks; new domain terms go in .cspell/project-words.txt.
+          config: ".cspell.json"
+          files: |
+            CLAUDE.md
+            docs/**/*.md
+            .claude/team/charter.md
+          incremental_files_only: false
+          strict: true
+
+  linkcheck:
+    name: Internal link-check (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          # .lychee.toml runs offline (internal/relative links only; external
+          # URL liveness is intentionally not gated — third-party uptime must
+          # not flake the docs gate). A broken relative cross-reference fails.
+          # The split org-charter cross-refs (../../../.claude/team/charter/*.md,
+          # in the parent repo) are excluded there — intended cross-repo refs.
+          args: "--config .lychee.toml --no-progress './**/*.md'"
+          fail: true
+
   config-lint:
     name: Config — YAML/JSON syntax
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -109,7 +152,7 @@ jobs:
     name: Config — Workflow actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,48 @@
+# lychee link-checker config for noorinalabs-user-service docs (#326).
+#
+# Purpose: catch BROKEN INTERNAL cross-references between docs (e.g. the ADRs,
+# schema doc, and CLAUDE.md link to each other; a renamed or missing target is a
+# real defect). External-URL liveness is intentionally NOT gated here — it
+# depends on third-party uptime and would make CI flaky and non-deterministic (a
+# 503 on some unrelated site should never block a docs PR). External links are
+# excluded; internal/relative links are checked.
+#
+# Cross-repo org-charter escapes are ALSO excluded (see the exclude list): this
+# repo's `.claude/team/charter.md` links to the SPLIT org charter via
+# `../../../.claude/team/charter/<file>.md`, which lives in the parent
+# noorinalabs-main repo (one directory up in the real org layout), NOT in this
+# repo's lone CI checkout. Those targets are out of scope for an in-repo link
+# gate for the same reason external URLs are — the gate can't assume a sibling
+# repo is present. The charter.md split links are the canonical, intended
+# cross-repo references, not defects.
+
+# Only check local filesystem + relative links; skip all remote schemes.
+scheme = ["file"]
+
+# Treat these as offline-only — never make network requests.
+offline = true
+
+# Exclude link targets that are not real broken-link signals.
+exclude = [
+  # mailto / external hosts handled separately; bare example hosts in prose.
+  '^https?://',
+  '^mailto:',
+  # GitHub issue/PR shorthand like `#326` is not a URL.
+  '^#\d+$',
+  # Cross-repo org-charter escapes — `.claude/team/charter/<file>.md` is the
+  # SPLIT org charter in the parent noorinalabs-main repo, reached via
+  # `../../../`; it is not present in this repo's standalone CI checkout. These
+  # are intended cross-repo refs, not broken links (see header note). Matches
+  # both the raw relative form and the resolved file:// path.
+  'charter/(agents|branching|commits|communication|hooks|issues|pull-requests|tech-decisions)\.md$',
+]
+
+# Don't descend into generated/vendored trees.
+exclude_path = [
+  "node_modules",
+  ".venv",
+  ".claude/worktrees",
+]
+
+# A relative link with no matching file is the failure we DO want to surface.
+require_https = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,11 @@
 #   * CI runs `uv run ruff/pytest`; the heavier local hooks use `uv run` too so
 #     the exact pinned tool versions from uv.lock run locally, never a stray
 #     global ruff/mypy. ruff itself runs via the ruff-pre-commit mirror, pinned
-#     to match `ruff>=0.8.0` in pyproject's dev extra (bump in lockstep).
+#     to v0.15.11 to match the org sibling convention (isnad-graph / parent).
+#   * actionlint mirrors the `Config — Workflow actionlint` job in docs.yml. The
+#     sync-drift gate globs ALL workflow files, so a CI-enforced `actionlint`
+#     kind not mirrored here would turn the gate red — this hook is what keeps
+#     the (now unscoped) gate green (matches parent #571/#572 direction).
 #   * pytest MUST run with ENVIRONMENT=test (the repo's test env-guard /
 #     conftest require it); the entry sets it inline.
 #   * mypy is run here at pre-push as STRICTER-LOCAL: it is configured in
@@ -29,21 +33,34 @@
 #     catches type regressions before push. If CI later adds mypy, the mirror is
 #     already in place.
 #
-# The kind-level mirror (ruff-lint, ruff-format, pytest present on both sides) is
-# enforced in CI by `.claude/lib/pre_commit_ci_sync.py` — if a future edit drops
-# one side, that gate fails the build. The gate is scoped to ci.yml (the code-CI
-# workflow); docs.yml gates a separate artifact class (markdown/config/
-# actionlint) that pre-commit intentionally does not mirror.
+# The kind-level mirror (ruff-lint, ruff-format, pytest, actionlint present on
+# both sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py`, which now
+# scans ALL workflows (ci.yml + docs.yml) — if a future edit drops one side, that
+# gate fails the build.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.11
     hooks:
       - id: ruff-format
         name: ruff-format
       - id: ruff
         args: [--fix]
         name: ruff-lint
+
+  # actionlint mirrors docs.yml's `Config — Workflow actionlint` job so the
+  # sync-drift gate (which globs all workflows) stays green. The upstream golang
+  # hook builds a pinned actionlint and already scopes to ^.github/workflows/.
+  # shellcheck MUST be on PATH so actionlint's embedded shellcheck integration
+  # runs rather than silently skipping (feedback_actionlint_needs_shellcheck) —
+  # CI gets it from ubuntu-latest's preinstalled shellcheck; locally, install
+  # shellcheck before committing. Pinned v1.7.12 to match what CI's
+  # download-actionlint.bash (tracking the latest release) resolves to.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        name: actionlint
 
   # Heavier checks run at pre-push (mirror CI's pytest job + the strict mypy from
   # `make check`). Run as `local`/`system` hooks via `uv run` so the pinned


### PR DESCRIPTION
## Summary

Alignment follow-up to the merged #141 pilot. The owner ratified the **full canonical docs-CI set**, so user-service moves from the pilot's deferred/scoped shape to the org standard.

### #326 — full docs-CI set (added cspell + lychee)
- `docs.yml`: added **Spellcheck (cspell)** + **Internal link-check (lychee)** jobs (modeled on the landing-page pilot). Widened path triggers to `**/*.json`, `**/*.jsonc`, `.cspell.json`, `.cspell/**`, `.lychee.toml`. Bumped checkout actions to v6.
- `.cspell.json` + `.cspell/project-words.txt` — scoped to authored prose (`CLAUDE.md`, `docs/`, `.claude/team/charter.md`). project-words holds the domain/library/team-name terms (Noorin, noorinalabs, isnad, joserfc, worktree, + charter-referenced team names).
- `.lychee.toml` — offline internal-link check. **Exclude carries the 8 split-charter parent cross-refs** (`../../../.claude/team/charter/{agents,branching,commits,communication,hooks,issues,pull-requests,tech-decisions}.md`) — these resolve into the parent `noorinalabs-main` repo, not this repo's standalone CI checkout, so they're intended cross-repo refs, not broken links. Confirmed those 8 are the *only* out-of-tree relative links in the repo.

### #327 — actionlint mirror + unscoped sync gate + ruff bump
- Added the pinned **actionlint pre-commit hook** (`rhysd/actionlint` rev **v1.7.12**, scoped to `.github/workflows/` by the upstream hook) so docs.yml's actionlint kind is mirrored locally.
- Bumped **`ruff-pre-commit` v0.11.6 → v0.15.11** (org sibling convention).
- **Unscoped the sync-drift gate** toward the canonical all-workflows direction (parent #571/#572) — it now scans **both quality-gate workflows** (`ci.yml` + `docs.yml`); the actionlint mirror keeps it green.

## ⚠️ user-service-specific deviation (review point)
The bare unscoped `pre_commit_ci_sync.py .` **fails** for this repo, because user-service uniquely has **`ghcr-publish.yml`** — a release-time container build/push whose `docker build` classifies as a `build` kind. That is NOT a local fast-feedback check pre-commit should mirror (the parent/landing repos have no such publish workflow; landing's `build` kind comes from a PR-gate `npm run build`, which it does mirror). So the gate is scoped to the **two quality-gate workflows** (`--ci ci.yml --ci docs.yml`), excluding only `ghcr-publish.yml`. This honors "scan all the quality gates including docs.yml" without forcing a nonsensical docker-build pre-commit hook. **Flagging for explicit review** — this is the one place I diverged from a literal bare-`.` invocation, and it should inform the other child repos' rollout if any of them also carry a publish workflow.

## Related Issues
- Refs noorinalabs-main#326
- Refs noorinalabs-main#327

## Verification (local, all green)
- `pre_commit_ci_sync.py . --ci ci.yml --ci docs.yml` — **OK**, exit 0 (actionlint mirrored both sides; mypy stricter-local, informational)
- `uv run ruff check .` / `ruff format --check .` / `mypy src/` — clean
- app test suite — **249 passed**; gate unit tests — **11 passed**
- markdownlint — 11 files, 0 errors
- cspell — 4 files, 0 issues
- lychee — 0 errors (all 8 charter escapes excluded)
- actionlint — all workflows clean
- `pre-commit run actionlint/ruff/ruff-format --all-files` — Pass, no autofix drift

## Review Checklist
- [ ] cspell `files` scope + project-words set acceptable (no over-suppression)
- [ ] lychee charter-escape exclude regex correct (8 split filenames)
- [ ] actionlint pin v1.7.12 matches CI's download-actionlint resolution
- [ ] ruff bump to 0.15.11 surfaces no new lint (verified: clean, no autofix)
- [ ] **sync-gate scoping to ci.yml+docs.yml (excluding ghcr-publish.yml) is the right call**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Anya Kowalczyk <parametrization+Anya.Kowalczyk@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
