### PR TITLE
ci(docs): pin + SHA256-verify actionlint installer (Refs #578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -153,10 +153,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships.
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color


### PR DESCRIPTION
## What

user-service slice of the org-wide **#578** rollout: pin + SHA256-verify the `actionlint` installer in `.github/workflows/docs.yml`.

Replaces the single unpinned step:
```yaml
bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
./actionlint -color
```
with two steps — a pinned download of **actionlint v1.7.12** + `sha256sum -c` against upstream's published `checksums.txt`, then a plain `actionlint -color` run (binary now on `/usr/local/bin`, so no `./` prefix). No `-ignore` flags (user-service has none).

## Why

Fetching+executing `download-actionlint.bash` off `main` each run is a supply-chain gap and diverges from the pinned **v1.7.12** the `.pre-commit-config.yaml` mirror already ships. Pinning + checksum-verify makes the bytes-on-runner exactly what was published at release time.

## Verification

- SHA256 `8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8` independently re-verified three ways: local download, against upstream `actionlint_1.7.12_checksums.txt` (linux_amd64), and the parent PR #579 provenance.
- `actionlint -color` run locally (shellcheck 0.10.0 on PATH so the embedded shellcheck integration actually runs) over the changed `docs.yml` and all workflows — exit 0, clean.
- Patch verified against this repo's `docs.yml` at origin HEAD (wave-15 == main for this blob) before applying — not trusted blindly.

## Test Plan (runtime)
- [ ] `Config — Workflow actionlint` job green in CI on this PR (the real proof the pinned installer + checksum step run on the runner) — confirm via `statusCheckRollup`.

Refs noorinalabs-main#578
