### PR TITLE
docs(branch-protection): SPEC.md — omit required_status_checks rule, don't pass [] (Refs noorinalabs-main#322)

### DIFF
--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -57,6 +57,28 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
   reported at least once on the default branch. **Re-confirm all contexts at
   apply time** against live check-runs — job names can change:
   `gh api repos/<repo>/commits/<default-sha>/check-runs --jq '.check_runs[].name'`.
+
+  > **Two apply-time gotchas (P3W15 org-wide rollout, main#322).**
+  >
+  > 1. **Path-filtered-CI repos: OMIT the rule, do not pass `[]`.** A repo whose
+  >    `ci.yml` carries a `paths:` filter (e.g. `noorinalabs-main`,
+  >    `noorinalabs-deploy`) has no *unconditional* gate context to require — a
+  >    docs/status-only PR would deadlock waiting on a check that never runs.
+  >    Such a ruleset must **drop the entire `required_status_checks` rule
+  >    object** from `rules`. It must **not** include the rule with an empty
+  >    `required_status_checks` array: the GitHub REST `/rulesets` endpoint
+  >    **rejects** that with `HTTP 422 — Invalid parameter
+  >    required_status_checks: Expected at least 1 elements, got 0`. (A
+  >    committed `ruleset-main.json` that ships the empty-array form is
+  >    delivered-but-never-applicable — it 422s on every apply.) The ruleset
+  >    still enforces PR-only + no-force-push; per-PR merge-on-red stays with
+  >    Hook 14 (`validate_pr_ci_status`).
+  > 2. **Matrix jobs expand their context name.** A matrix job surfaces its
+  >    check-run as `<job> (<matrix-value>)` — e.g. design-system's `ci` job
+  >    (`node-version: [20.x]`) reports as `ci (20.x)`. Requiring the bare `ci`
+  >    context would never go green. Always copy the **exact live check-run
+  >    name** from the `check-runs` query above into the context, matrix
+  >    expansion included.
 - **`deletion` + `non_fast_forward`** — no force-push / branch-delete on `main`.
 - **`bypass_actors`: Repository-admin (`actor_id: 5`, `bypass_mode: always`)** —
   keeps the orchestrator's `--admin` wave→main wrapup merges and the charter


### PR DESCRIPTION
## What

Documents two apply-time gotchas in the **canonical** branch-protection `SPEC.md`, surfaced during the P3W15 org-wide ruleset rollout (`noorinalabs-main#322`, 8/8 applied + verified). Doc-only — no payload or script change.

1. **Path-filtered-CI repos: OMIT the `required_status_checks` rule, don't pass `[]`.** The GitHub REST `/rulesets` endpoint **rejects** a `required_status_checks` rule with an empty array (`HTTP 422 — Expected at least 1 elements, got 0`). Repos whose `ci.yml` is path-filtered (`noorinalabs-main`, `noorinalabs-deploy`) have no unconditional gate context to require, so they must **drop the rule entirely**. A committed `ruleset-main.json` shipping the empty-array form is delivered-but-never-applicable (it 422s on every apply — deploy's committed JSON had exactly this latent bug). PR-only + no-force-push still enforced; per-PR merge-on-red stays with Hook 14.
2. **Matrix jobs expand their context name** (e.g. `ci` → `ci (20.x)`). Copy the exact live check-run name, matrix expansion included.

## Why here

This is the canonical branch-protection SPEC the other 7 repos model their ruleset on, so the correction belongs here to stop the pattern propagating. Closes the loop on the systemic finding from the #322 rollout while it's fresh.

## Verification
- Doc-only; renders as a blockquote callout under the `required_status_checks` bullet.
- The 8/8 live rulesets already follow this (main + deploy applied with the rule omitted; design-system with `ci (20.x)`) — see noorinalabs-main#322 evidence table.

Refs noorinalabs-main#322. Companion sync-backs: noorinalabs-deploy#395, noorinalabs-design-system#94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
