### PR TITLE
security(#520): recover stranded OAuth hardening (us#68/#69/#55) + crypto refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,12 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
 
 # Auth
 AUTH_PASSWORD_MIN_LENGTH=8
+# Per-IP rate limit on auth endpoints: AUTH_MAX_LOGIN_ATTEMPTS requests per
+# AUTH_LOCKOUT_DURATION_MINUTES window, then HTTP 429. Backed by Redis.
 AUTH_MAX_LOGIN_ATTEMPTS=5
 AUTH_LOCKOUT_DURATION_MINUTES=15
+# Toggle auth-endpoint rate limiting. Defaults to true; set false for local dev.
+AUTH_RATE_LIMIT_ENABLED=true
 
 # OAuth — Google
 AUTH_GOOGLE_CLIENT_ID=

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -10,6 +10,15 @@ _PROD_LIKE_ENVIRONMENTS = frozenset({"production", "staging"})
 _ALLOWED_ENVIRONMENTS = frozenset({"development", "test", "staging", "production"})
 
 
+def _host_of(url: str) -> str | None:
+    """Return the lowercased hostname of an absolute URL, or None if it has no host.
+
+    Used to build the AUTH_OAUTH_POST_LOGIN_URL allowlist from other URL settings.
+    """
+    parsed = urlparse(url)
+    return parsed.hostname.lower() if parsed.hostname else None
+
+
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
@@ -38,6 +47,11 @@ class Settings(BaseSettings):
     AUTH_PASSWORD_MIN_LENGTH: int = 8
     AUTH_MAX_LOGIN_ATTEMPTS: int = 5
     AUTH_LOCKOUT_DURATION_MINUTES: int = 15
+    # Per-IP rate limiting on auth endpoints (token issue/refresh/validate, OAuth
+    # callback). Backed by Redis; uses AUTH_MAX_LOGIN_ATTEMPTS as the per-window
+    # limit and AUTH_LOCKOUT_DURATION_MINUTES as the window length. Disable only
+    # for local dev / tests where the speed-bump gets in the way.
+    AUTH_RATE_LIMIT_ENABLED: bool = True
 
     # OAuth — Google
     AUTH_GOOGLE_CLIENT_ID: str = ""
@@ -152,6 +166,99 @@ class Settings(BaseSettings):
                 "ENVIRONMENT=test (no HTTP downgrade)"
             )
             raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_oauth_post_login_url(self) -> Self:
+        """Open-redirect hardening for AUTH_OAUTH_POST_LOGIN_URL (#69).
+
+        The OAuth callback redirects the browser — with a freshly minted access
+        token attached — to this URL. It is operator-controlled (an env var, no
+        `?next=` override) so it is not an exploitable open redirect today, but a
+        misconfigured or compromised deploy config should not be able to divert
+        token-bearing traffic to an attacker host. Validation runs at boot so a
+        bad value fails fast rather than at request time.
+
+        Accepted:
+          - a same-origin relative URL starting with a single `/`, OR
+          - an absolute URL whose host is in the allowlist derived from
+            AUTH_OAUTH_REDIRECT_BASE_URL + CORS_ORIGINS.
+
+        Rejected everywhere: `javascript:` / `data:` schemes, and
+        protocol-relative `//host` URLs (urlparse reads `//host` as netloc with
+        an empty scheme — a classic open-redirect bypass). Rejected outside
+        ENVIRONMENT=development/test: absolute URLs with a non-`https` scheme.
+        """
+        value = self.AUTH_OAUTH_POST_LOGIN_URL
+        if not value:
+            msg = "AUTH_OAUTH_POST_LOGIN_URL must not be empty"
+            raise ValueError(msg)
+
+        parsed = urlparse(value)
+
+        # Protocol-relative (`//evil.com/path`): no scheme but a netloc. urlparse
+        # treats this as having a host — reject before the relative-path branch.
+        if not parsed.scheme and parsed.netloc:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL must not be protocol-relative "
+                f"(`//host`), got: {value!r}"
+            )
+            raise ValueError(msg)
+
+        # Same-origin relative URL: starts with a single `/` (not `//`), no scheme,
+        # no netloc. This is the safe common case.
+        if not parsed.scheme and not parsed.netloc:
+            if not value.startswith("/"):
+                msg = (
+                    "AUTH_OAUTH_POST_LOGIN_URL must be an absolute https URL or a "
+                    f"same-origin path starting with '/', got: {value!r}"
+                )
+                raise ValueError(msg)
+            # A leading `/` followed by `/` or `\` is not same-origin: browsers
+            # normalize `\` -> `/` in http(s) URLs per the WHATWG URL spec, so
+            # `/\host` becomes the protocol-relative `//host` at navigation time
+            # — a classic open-redirect bypass that slips past urlparse (which
+            # does not treat `\` as a netloc delimiter). Reject any backslash:
+            # there is no legitimate use for one in this path, and a blanket
+            # reject closes the whole variant family (`/\`, `/foo\@host`, ...).
+            if value.startswith(("//", "/\\")) or "\\" in value:
+                msg = (
+                    "AUTH_OAUTH_POST_LOGIN_URL must not contain backslashes or be "
+                    f"protocol-relative, got: {value!r}"
+                )
+                raise ValueError(msg)
+            return self
+
+        # Absolute URL from here on. Reject dangerous schemes outright.
+        if parsed.scheme not in {"http", "https"}:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL scheme must be https (or http in "
+                f"development/test), got: {parsed.scheme!r}"
+            )
+            raise ValueError(msg)
+
+        # Non-https absolute URL only tolerated in development/test.
+        if parsed.scheme != "https" and self.ENVIRONMENT not in {"development", "test"}:
+            msg = (
+                "AUTH_OAUTH_POST_LOGIN_URL must use https:// outside "
+                f"ENVIRONMENT=development/test, got: {value!r}"
+            )
+            raise ValueError(msg)
+
+        # Host must be in the allowlist derived from the other trusted URL settings.
+        allowed_hosts = {_host_of(self.AUTH_OAUTH_REDIRECT_BASE_URL)}
+        allowed_hosts.update(_host_of(origin) for origin in self.CORS_ORIGINS)
+        allowed_hosts.discard(None)
+
+        host = parsed.hostname.lower() if parsed.hostname else None
+        if host not in allowed_hosts:
+            msg = (
+                f"AUTH_OAUTH_POST_LOGIN_URL host {host!r} is not in the allowlist "
+                f"derived from AUTH_OAUTH_REDIRECT_BASE_URL + CORS_ORIGINS "
+                f"({sorted(h for h in allowed_hosts if h)}), got: {value!r}"
+            )
+            raise ValueError(msg)
+
         return self
 
 

--- a/src/app/database.py
+++ b/src/app/database.py
@@ -3,20 +3,26 @@
 from collections.abc import AsyncGenerator
 
 from redis.asyncio import Redis
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from src.app.config import get_settings
 
+_engine: AsyncEngine | None = None
 _async_session_factory: async_sessionmaker[AsyncSession] | None = None
 _redis_client: Redis | None = None
 
 
 async def init_db() -> None:
     """Initialize the database engine and session factory."""
-    global _async_session_factory
+    global _engine, _async_session_factory
     settings = get_settings()
-    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
-    _async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    _engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    _async_session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 
 
 async def init_redis() -> None:
@@ -28,12 +34,10 @@ async def init_redis() -> None:
 
 async def close_db() -> None:
     """Dispose the engine and clear the session factory."""
-    global _async_session_factory
-    if _async_session_factory is not None:
-        # Get engine from the session factory bind
-        engine = _async_session_factory.kw.get("bind")
-        if engine is not None:
-            await engine.dispose()
+    global _engine, _async_session_factory
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
     _async_session_factory = None
 
 
@@ -55,4 +59,14 @@ async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
 async def get_redis() -> AsyncGenerator[Redis, None]:
     """FastAPI dependency that yields the Redis client."""
     assert _redis_client is not None, "Redis not initialized"
+    yield _redis_client
+
+
+async def get_redis_optional() -> AsyncGenerator[Redis | None, None]:
+    """FastAPI dependency that yields the Redis client, or None if uninitialized.
+
+    Unlike `get_redis`, this never raises. It exists for non-critical, fail-open
+    consumers (e.g. the auth rate limiter) that must degrade gracefully rather
+    than 500 the request when Redis is unavailable.
+    """
     yield _redis_client

--- a/src/app/routers/auth.py
+++ b/src/app/routers/auth.py
@@ -7,8 +7,11 @@ OAuth flow (server-side, post #66):
   3. Provider redirects the browser to GET /auth/oauth/{provider}/callback?code=..&state=..
   4. Backend validates state, exchanges code, upserts user, mints tokens, sets the
      refresh_token as an httpOnly cookie, and redirects the browser to
-     AUTH_OAUTH_POST_LOGIN_URL with ?token=<access>&is_new_user=0|1 on success,
-     or ?error=<code> on failure.
+     AUTH_OAUTH_POST_LOGIN_URL. On success the access token is delivered in the
+     URL *fragment* (`#token=<access>`) so it never leaks via the Referer header
+     (#68), while the non-secret flags stay as query params
+     (`?is_new_user=0|1&needs_verification=0`). On failure the redirect carries
+     `?error=<code>`.
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.app.config import Settings, get_settings
-from src.app.database import get_db_session, get_redis
+from src.app.database import get_db_session, get_redis, get_redis_optional
 from src.app.models.user import User
 from src.app.schemas.auth import (
     OAuthLoginResponse,
@@ -41,6 +44,7 @@ from src.app.schemas.auth import (
     TokenValidationResponse,
 )
 from src.app.services.oauth import OAuthProvider, generate_pkce_pair, get_oauth_provider
+from src.app.services.rate_limit import check_rate_limit, enforce_ip_rate_limit
 from src.app.services.subscription import get_subscription_status
 from src.app.services.token import (
     create_access_token,
@@ -59,6 +63,9 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 DbDep = Annotated[AsyncSession, Depends(get_db_session)]
 RedisDep = Annotated[Redis, Depends(get_redis)]
+# Fail-open Redis handle for the rate limiter — yields None if Redis is down so
+# a limiter-backend outage degrades to "no limiting" rather than a 500.
+RateLimitRedisDep = Annotated[Redis | None, Depends(get_redis_optional)]
 
 AUTH_CODE_PREFIX = "auth_code:"
 AUTH_CODE_TTL_SECONDS = 60
@@ -74,6 +81,7 @@ OAUTH_ERROR_USER_INFO_FAILED = "oauth_exchange_failed"
 OAUTH_ERROR_EMAIL_MISMATCH = "email_mismatch"
 OAUTH_ERROR_PROVIDER_DENIED = "provider_denied"
 OAUTH_ERROR_UNSUPPORTED_PROVIDER = "unsupported_provider"
+OAUTH_ERROR_RATE_LIMITED = "rate_limited"
 
 VALID_PROVIDERS = {p.value for p in OAuthProvider}
 
@@ -88,12 +96,15 @@ async def issue_token(
     settings: SettingsDep,
     db: DbDep,
     redis: RedisDep,
+    rl_redis: RateLimitRedisDep,
 ) -> TokenResponse:
     """Issue an access + refresh token pair after OAuth success.
 
     Requires a one-time authorization code issued by the OAuth callback endpoint.
     The code is single-use and expires after 60 seconds.
     """
+    await enforce_ip_rate_limit(request, rl_redis, settings, bucket="token")
+
     redis_key = f"{AUTH_CODE_PREFIX}{body.authorization_code}"
     raw = await redis.getdel(redis_key)
     if raw is None:
@@ -138,14 +149,28 @@ async def refresh_token(
     request: Request,
     settings: SettingsDep,
     db: DbDep,
+    rl_redis: RateLimitRedisDep,
 ) -> TokenResponse:
     """Exchange a refresh token for a new access token (with rotation)."""
+    # Rate-limit by IP before touching the token store — blocks a single host
+    # from hammering refresh/rotation regardless of which token it presents.
+    await enforce_ip_rate_limit(request, rl_redis, settings, bucket="refresh")
+
     session = await validate_refresh_token(db, body.refresh_token)
     if session is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
+
+    # Secondary per-user rate limit: caps refresh churn for one account even if
+    # the attacker rotates source IPs. Keyed by user_id, separate bucket.
+    await check_rate_limit(
+        rl_redis,
+        settings,
+        bucket="refresh_user",
+        identifier=str(session.user_id),
+    )
 
     # Rotate: revoke old, issue new
     await revoke_refresh_token(db, body.refresh_token)
@@ -207,10 +232,14 @@ async def revoke_token(body: RevokeRequest, db: DbDep) -> None:
 
 @router.get("/token/validate", response_model=TokenValidationResponse)
 async def validate_token(
+    request: Request,
     settings: SettingsDep,
+    rl_redis: RateLimitRedisDep,
     authorization: Annotated[str, Header()],
 ) -> TokenValidationResponse:
     """Validate an access token (for cross-service calls)."""
+    await enforce_ip_rate_limit(request, rl_redis, settings, bucket="validate")
+
     scheme, _, token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not token:
         return TokenValidationResponse(valid=False)
@@ -236,7 +265,12 @@ async def validate_token(
 # --- OAuth Endpoints ---
 
 
-def _build_post_login_url(settings: Settings, provider: str, params: dict[str, str]) -> str:
+def _build_post_login_url(
+    settings: Settings,
+    provider: str,
+    params: dict[str, str],
+    fragment_params: dict[str, str] | None = None,
+) -> str:
     """Build the post-login redirect URL.
 
     `AUTH_OAUTH_POST_LOGIN_URL` is the BASE path (e.g. `/auth/callback`); the
@@ -250,14 +284,23 @@ def _build_post_login_url(settings: Settings, provider: str, params: dict[str, s
     `provider` comes from the FastAPI path parameter, which is validated
     against `VALID_PROVIDERS` in every caller — never user-supplied arbitrary
     text at this point.
+
+    `params` are emitted as the query string; `fragment_params` (if any) are
+    emitted as the URL fragment. Per #68, the access token is delivered in the
+    fragment so it never leaks via the `Referer` header — fragments are not
+    sent in `Referer` by any browser. Non-secret flags (`is_new_user`,
+    `needs_verification`, `error`) stay as query params so SSR / server logs
+    can still observe them.
     """
     base = (settings.AUTH_OAUTH_POST_LOGIN_URL or "/").rstrip("/")
     # URL-encode the provider even though we only ever pass validated values —
     # belt-and-braces in case VALID_PROVIDERS ever includes a special character.
     path = f"{base}/{urllib.parse.quote(provider, safe='')}"
-    if not params:
-        return path
-    return f"{path}?{urllib.parse.urlencode(params)}"
+    if params:
+        path = f"{path}?{urllib.parse.urlencode(params)}"
+    if fragment_params:
+        path = f"{path}#{urllib.parse.urlencode(fragment_params)}"
+    return path
 
 
 def _build_error_redirect(settings: Settings, provider: str, error_code: str) -> RedirectResponse:
@@ -310,6 +353,7 @@ async def oauth_callback_get(
     settings: SettingsDep,
     db: DbDep,
     redis: RedisDep,
+    rl_redis: RateLimitRedisDep,
     code: str | None = Query(default=None),
     state: str | None = Query(default=None),
     error: str | None = Query(default=None),
@@ -332,6 +376,16 @@ async def oauth_callback_get(
 
     Issue: noorinalabs/noorinalabs-user-service#66.
     """
+    # Per-IP rate limit. This endpoint is browser-facing, so a raised 429 would
+    # be a dead end — instead bounce to the frontend with a rate_limited error
+    # code (consistent with every other exit path here).
+    try:
+        await enforce_ip_rate_limit(request, rl_redis, settings, bucket="oauth_callback")
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
+            return _build_error_redirect(settings, provider, OAUTH_ERROR_RATE_LIMITED)
+        raise
+
     # Provider-denied consent (e.g. "access_denied") → bounce to frontend with error
     if error:
         return _build_error_redirect(settings, provider, OAUTH_ERROR_PROVIDER_DENIED)
@@ -443,9 +497,11 @@ async def oauth_callback_get(
     subscription_status = await get_subscription_status(db, result.user.id)
 
     # Mint tokens directly (no intermediate one-time code — the browser round-trip
-    # via redirect is already the single-use handoff). The access token goes on the
-    # redirect URL (the frontend AuthCallbackPage stores it in localStorage); the
-    # refresh token goes in an httpOnly cookie so JS cannot read it.
+    # via redirect is already the single-use handoff). The access token goes in the
+    # redirect URL *fragment* (the frontend AuthCallbackPage reads it from
+    # window.location.hash and stores it in localStorage) so it never leaks via the
+    # Referer header — see #68. The refresh token goes in an httpOnly cookie so JS
+    # cannot read it.
     access_token, _ = create_access_token(
         settings=settings,
         user_id=result.user.id,
@@ -463,20 +519,21 @@ async def oauth_callback_get(
         user_agent=request.headers.get("user-agent"),
     )
 
-    # Build the success redirect with the access token and new-user flag. The
-    # `/{provider}` segment is appended by _build_post_login_url to match the
-    # frontend route `auth/callback/:provider` (required param — see
+    # Build the success redirect: the access token goes in the URL fragment (#68
+    # — keeps it out of the Referer header), the non-secret flags stay as query
+    # params. The `/{provider}` segment is appended by _build_post_login_url to
+    # match the frontend route `auth/callback/:provider` (required param — see
     # isnad-graph/frontend/src/App.tsx:57 and isnad-graph#824).
     redirect_url = _build_post_login_url(
         settings,
         provider,
         {
-            "token": access_token,
             "is_new_user": "1" if result.is_new_user else "0",
             # OAuth users are created with email_verified=True, so verification is
             # never needed via this flow — but we emit the flag for frontend parity.
             "needs_verification": "0",
         },
+        fragment_params={"token": access_token},
     )
     response = RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
 

--- a/src/app/routers/sessions.py
+++ b/src/app/routers/sessions.py
@@ -1,6 +1,5 @@
 """Session management routes — US #7."""
 
-import hashlib
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request, status
@@ -19,12 +18,9 @@ from src.app.services.session import (
     revoke_session,
 )
 from src.app.services.token import create_refresh_token
+from src.app.utils.crypto import hash_token
 
 router = APIRouter(prefix="/api/v1/sessions", tags=["sessions"])
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
 
 
 @router.post(
@@ -40,7 +36,7 @@ async def create_user_session(
 ) -> SessionCreateResponse:
     """Create a new session for the authenticated user."""
     token = create_refresh_token()
-    token_hash = _hash_token(token)
+    token_hash = hash_token(token)
     session = await create_session(
         db=db,
         redis=redis,

--- a/src/app/services/rate_limit.py
+++ b/src/app/services/rate_limit.py
@@ -1,0 +1,141 @@
+"""Redis-backed per-client rate limiting for auth endpoints — US #55.
+
+The auth router endpoints (token issue, refresh, validate, OAuth callback) had
+no rate limiting, leaving them open to brute-force / credential-stuffing. This
+service implements a fixed-window counter keyed by client identifier (IP, and
+optionally a secondary discriminator such as user_id).
+
+Design notes:
+  * Fixed-window counter: INCR a per-window key, then EXPIRE it to the window
+    length on EVERY call. Cheap, atomic enough for this purpose (a burst
+    straddling a window boundary can briefly allow up to 2x the limit —
+    acceptable for a brute-force speed-bump; a sliding window would need a
+    sorted set and is not worth the complexity here).
+  * EXPIRE is re-asserted unconditionally, not just on the first hit. INCR and
+    EXPIRE are two separate round-trips: if EXPIRE failed on the first hit (a
+    transient Redis blip mid-call), a "set TTL only when counter == 1" approach
+    would leave the key orphaned with NO expiry — once Redis recovers it INCRs
+    forever and that identifier is permanently 429'd with no window reset.
+    Re-asserting EXPIRE every call makes the limiter self-healing: any orphaned
+    key gets its TTL back on the very next request. Resetting the TTL on each
+    call is fine — the window is "time since the most recent attempt", which is
+    the desired lockout semantics anyway.
+  * Fail-open: if Redis is unavailable or errors, the limiter allows the request
+    rather than hard-failing the whole auth surface. A rate limiter outage must
+    not become an auth outage. Failures are logged so the degradation is visible.
+  * Configurable: limits come from settings (AUTH_MAX_LOGIN_ATTEMPTS,
+    AUTH_LOCKOUT_DURATION_MINUTES) and the whole feature can be disabled with
+    AUTH_RATE_LIMIT_ENABLED.
+
+Runtime backend: requires the same Redis instance the rest of the service uses
+(REDIS_URL). No new infrastructure. See PR body for the runtime-acceptance note.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, Request, status
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from src.app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# Redis key namespace for auth rate-limit counters.
+RATE_LIMIT_PREFIX = "auth_rl:"
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP for rate-limit keying.
+
+    Uses the direct socket peer. We deliberately do NOT trust X-Forwarded-For
+    here — honoring a client-supplied header would let an attacker rotate the
+    rate-limit key at will. If/when the service runs behind a trusted proxy that
+    sets a verified forwarded header, this is the single place to revisit.
+    """
+    if request.client is None:
+        return "unknown"
+    return request.client.host
+
+
+async def check_rate_limit(
+    redis: Redis | None,
+    settings: Settings,
+    *,
+    bucket: str,
+    identifier: str,
+) -> None:
+    """Enforce the auth rate limit for one (bucket, identifier) pair.
+
+    `bucket` namespaces the limit (e.g. "token", "refresh", "oauth_callback") so
+    a client's budget on one endpoint is independent of another. `identifier` is
+    the client discriminator (typically an IP, optionally suffixed with a
+    user_id).
+
+    Raises HTTP 429 when the limit is exceeded. Returns None when the request is
+    allowed. Fails open (allows the request) when Redis is unavailable
+    (`redis is None`) or errors.
+    """
+    if not settings.AUTH_RATE_LIMIT_ENABLED:
+        return
+
+    if redis is None:
+        # Redis not initialized — fail open. A limiter-backend outage must not
+        # take down auth.
+        logger.warning(
+            "Rate limiter unavailable (Redis not initialized) — allowing request: bucket=%s",
+            bucket,
+        )
+        return
+
+    limit = settings.AUTH_MAX_LOGIN_ATTEMPTS
+    window_seconds = settings.AUTH_LOCKOUT_DURATION_MINUTES * 60
+    key = f"{RATE_LIMIT_PREFIX}{bucket}:{identifier}"
+
+    try:
+        current = await redis.incr(key)
+        # Re-assert the TTL on every call, not just when current == 1. INCR and
+        # EXPIRE are separate round-trips; if EXPIRE failed on the first hit the
+        # key would otherwise be orphaned without a TTL and INCR forever, giving
+        # that identifier a permanent 429. Unconditional re-assert is
+        # self-healing — an orphaned key gets its expiry back on the next call.
+        await redis.expire(key, window_seconds)
+    except RedisError:
+        # Fail open: a limiter-backend outage must not take down auth. Log so the
+        # degraded state is observable.
+        logger.warning(
+            "Rate limiter unavailable (Redis error) — allowing request: bucket=%s",
+            bucket,
+        )
+        return
+
+    if current > limit:
+        logger.info(
+            "Auth rate limit exceeded: bucket=%s limit=%s window_s=%s",
+            bucket,
+            limit,
+            window_seconds,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many requests — please try again later.",
+            headers={"Retry-After": str(window_seconds)},
+        )
+
+
+async def enforce_ip_rate_limit(
+    request: Request,
+    redis: Redis | None,
+    settings: Settings,
+    *,
+    bucket: str,
+) -> None:
+    """Convenience wrapper: rate-limit by client IP for the given bucket."""
+    await check_rate_limit(
+        redis,
+        settings,
+        bucket=bucket,
+        identifier=_client_ip(request),
+    )

--- a/src/app/services/token.py
+++ b/src/app/services/token.py
@@ -1,6 +1,5 @@
 """Token service — JWT issuance, validation, refresh, and revocation."""
 
-import hashlib
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -14,10 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.app.config import Settings
 from src.app.models.session import Session
 from src.app.services.keys import get_private_key, get_public_key, get_public_key_jwk
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
+from src.app.utils.crypto import hash_token
 
 
 def create_access_token(
@@ -71,7 +67,7 @@ async def store_refresh_token(
     user_agent: str | None = None,
 ) -> Session:
     """Store a hashed refresh token in the sessions table."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     expires_at = datetime.now(UTC) + timedelta(days=expires_days)
     session = Session(
         user_id=user_id,
@@ -87,7 +83,7 @@ async def store_refresh_token(
 
 async def validate_refresh_token(db: AsyncSession, refresh_token: str) -> Session | None:
     """Look up a refresh token and return the session if valid."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     now = datetime.now(UTC)
     result = await db.execute(
         select(Session).where(
@@ -101,7 +97,7 @@ async def validate_refresh_token(db: AsyncSession, refresh_token: str) -> Sessio
 
 async def revoke_refresh_token(db: AsyncSession, refresh_token: str) -> bool:
     """Revoke a refresh token. Returns True if a token was revoked."""
-    token_hash = _hash_token(refresh_token)
+    token_hash = hash_token(refresh_token)
     cursor_result: CursorResult[Any] = await db.execute(  # type: ignore[assignment]
         update(Session)
         .where(Session.token_hash == token_hash, Session.revoked_at.is_(None))

--- a/src/app/services/verification.py
+++ b/src/app/services/verification.py
@@ -6,7 +6,6 @@ and email dispatch.
 
 from __future__ import annotations
 
-import hashlib
 import html
 import secrets
 import uuid
@@ -21,10 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.app.config import Settings
 from src.app.models.user import User
 from src.app.models.verification_token import TokenType, VerificationToken
-
-
-def _hash_token(token: str) -> str:
-    return hashlib.sha256(token.encode()).hexdigest()
+from src.app.utils.crypto import hash_token
 
 
 async def check_rate_limit(
@@ -77,7 +73,7 @@ async def create_verification_token(
     await invalidate_existing_tokens(db, user_id)
 
     raw_token = secrets.token_urlsafe(32)
-    token_hash = _hash_token(raw_token)
+    token_hash = hash_token(raw_token)
     expires_at = datetime.now(UTC) + timedelta(hours=settings.VERIFICATION_TOKEN_EXPIRE_HOURS)
 
     verification_token = VerificationToken(
@@ -99,7 +95,7 @@ async def confirm_verification_token(
 
     Returns the User if successful, None if the token is invalid/expired/used.
     """
-    token_hash = _hash_token(raw_token)
+    token_hash = hash_token(raw_token)
     now = datetime.now(UTC)
 
     result = await db.execute(

--- a/src/app/utils/__init__.py
+++ b/src/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utility helpers."""

--- a/src/app/utils/crypto.py
+++ b/src/app/utils/crypto.py
@@ -1,0 +1,12 @@
+"""Cryptographic helpers shared across services and routers."""
+
+import hashlib
+
+
+def hash_token(token: str) -> str:
+    """Return the SHA-256 hex digest of an opaque token.
+
+    Used to store refresh tokens and verification tokens at rest as a hash
+    rather than the raw value. Callers compare hashes, never raw tokens.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/tests/test_config_post_login_url.py
+++ b/tests/test_config_post_login_url.py
@@ -1,0 +1,112 @@
+"""Tests for AUTH_OAUTH_POST_LOGIN_URL validation — open-redirect hardening (#69).
+
+The OAuth callback redirects the browser, with a freshly minted access token
+attached, to AUTH_OAUTH_POST_LOGIN_URL. It is operator-controlled today (env var,
+no `?next=` override) so not an exploitable open redirect — this validator is
+defence-in-depth: a misconfigured/compromised deploy config must fail fast at
+boot rather than divert token-bearing traffic to an attacker host.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.app.config import Settings
+
+
+def _make_settings(**overrides: object) -> Settings:
+    """Build a Settings instance with sane defaults for the post-login-URL tests.
+
+    Defaults ENVIRONMENT=production so the strict (https-only, allowlisted-host)
+    branch is exercised unless a test opts into development/test.
+    """
+    defaults: dict[str, object] = {
+        "ENVIRONMENT": "production",
+        "AUTH_OAUTH_REDIRECT_BASE_URL": "https://user-service.noorinalabs.com",
+        "CORS_ORIGINS": ["https://app.noorinalabs.com", "https://noorinalabs.com"],
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestPostLoginUrlAccepted:
+    def test_relative_url_accepted(self) -> None:
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "/auth/callback"
+
+    def test_default_value_is_valid(self) -> None:
+        # The shipped default must pass its own validator.
+        s = _make_settings()
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "/auth/callback"
+
+    def test_absolute_url_on_redirect_base_host_accepted(self) -> None:
+        s = _make_settings(
+            AUTH_OAUTH_POST_LOGIN_URL="https://user-service.noorinalabs.com/auth/callback"
+        )
+        assert s.AUTH_OAUTH_POST_LOGIN_URL.endswith("/auth/callback")
+
+    def test_absolute_url_on_cors_origin_host_accepted(self) -> None:
+        # Host present in CORS_ORIGINS but not AUTH_OAUTH_REDIRECT_BASE_URL.
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://app.noorinalabs.com/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "https://app.noorinalabs.com/auth/callback"
+
+    def test_host_match_is_case_insensitive(self) -> None:
+        s = _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://APP.NoorinALabs.com/auth/callback")
+        assert s.AUTH_OAUTH_POST_LOGIN_URL.startswith("https://APP")
+
+    def test_http_absolute_url_allowed_in_development(self) -> None:
+        # localhost dev: CORS_ORIGINS carries the http host, ENVIRONMENT=development.
+        s = _make_settings(
+            ENVIRONMENT="development",
+            AUTH_OAUTH_REDIRECT_BASE_URL="http://localhost:8000",
+            CORS_ORIGINS=["http://localhost:3000"],
+            AUTH_OAUTH_POST_LOGIN_URL="http://localhost:3000/auth/callback",
+        )
+        assert s.AUTH_OAUTH_POST_LOGIN_URL == "http://localhost:3000/auth/callback"
+
+
+class TestPostLoginUrlRejected:
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must not be empty"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="")
+
+    def test_protocol_relative_url_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="protocol-relative"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="//evil.com/auth/callback")
+
+    def test_javascript_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="scheme must be https"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="javascript:alert(document.cookie)")
+
+    def test_data_scheme_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="scheme must be https"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="data:text/html,<script>1</script>")
+
+    def test_off_allowlist_host_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not in the allowlist"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="https://evil.com/auth/callback")
+
+    def test_http_absolute_url_rejected_in_production(self) -> None:
+        # Host would be allowlisted, but http:// is rejected outside dev/test.
+        with pytest.raises(ValidationError, match="must use https"):
+            _make_settings(
+                CORS_ORIGINS=["http://app.noorinalabs.com"],
+                AUTH_OAUTH_POST_LOGIN_URL="http://app.noorinalabs.com/auth/callback",
+            )
+
+    def test_relative_url_without_leading_slash_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="starting with '/'"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="auth/callback")
+
+    def test_backslash_relative_url_rejected(self) -> None:
+        # `/\evil.com` passes urlparse as a relative path (backslash is not a
+        # netloc delimiter), but browsers normalize `\`->`/`, turning it into the
+        # protocol-relative `//evil.com` at navigation time — CWE-601 bypass.
+        with pytest.raises(ValidationError, match="must not contain backslashes"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/\\evil.com")
+
+    def test_backslash_anywhere_in_relative_url_rejected(self) -> None:
+        # Blanket backslash reject — not just the leading `/\` case.
+        with pytest.raises(ValidationError, match="must not contain backslashes"):
+            _make_settings(AUTH_OAUTH_POST_LOGIN_URL="/auth\\callback")

--- a/tests/test_oauth_callback_get.py
+++ b/tests/test_oauth_callback_get.py
@@ -178,9 +178,15 @@ class TestOAuthCallbackGet:
         # must-fix on PR#67.
         assert parsed.path == "/auth/callback/google"
         qs = parse_qs(parsed.query)
-        assert "token" in qs
+        # Per #68 the access token is delivered in the URL *fragment*, not the
+        # query string — fragments are never sent in the Referer header. The
+        # non-secret flags stay as query params.
+        assert "token" not in qs
         assert qs["is_new_user"] == ["0"]
         assert qs["needs_verification"] == ["0"]
+        frag = parse_qs(parsed.fragment)
+        assert "token" in frag
+        assert frag["token"][0]
         # Refresh token must be set as an httpOnly cookie
         set_cookie = resp.headers.get("set-cookie", "")
         assert "refresh_token=" in set_cookie
@@ -299,6 +305,71 @@ class TestOAuthCallbackGet:
         oauth_mock.get_user_info.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_exchange_code_called_with_configured_redirect_uri(
+        self,
+        client_factory: Any,
+        fake_user: User,
+    ) -> None:
+        """exchange_code must receive the redirect_uri built from AUTH_OAUTH_REDIRECT_BASE_URL.
+
+        Gap 3 on #70. The happy-path test asserts the redirect *response* but
+        never inspects what redirect_uri was handed to the provider. A prod
+        misconfig (AUTH_OAUTH_REDIRECT_BASE_URL unset/wrong) would pass every
+        other test and only fail at integration time with redirect_uri_mismatch.
+        """
+        state = "redirect-uri-state"
+        seed = {
+            f"oauth_state:{state}": json.dumps(
+                {"provider": "google", "code_verifier": "pkce-verifier"}
+            ),
+        }
+
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g-123",
+                email="mateo@example.com",
+                display_name="Mateo Test",
+                avatar_url=None,
+            )
+        )
+
+        with (
+            patch("src.app.routers.auth.get_oauth_provider", return_value=oauth_mock),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake_user, is_new_user=False),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc123", "state": state},
+                )
+
+        assert resp.status_code == 302
+        # _test_settings sets AUTH_OAUTH_REDIRECT_BASE_URL to this host; the
+        # handler appends /auth/oauth/{provider}/callback.
+        oauth_mock.exchange_code.assert_awaited_once_with(
+            "abc123",
+            "pkce-verifier",
+            "https://isnad-graph.noorinalabs.com/auth/oauth/google/callback",
+        )
+
+    @pytest.mark.asyncio
     async def test_state_is_consumed_exactly_once(self, client_factory: Any) -> None:
         """Replaying the callback URL with the same state must fail the second time."""
         state = "replay-state"
@@ -350,7 +421,10 @@ class TestOAuthCallbackGet:
                     params={"code": "abc", "state": state},
                 )
                 assert first.status_code == 302
-                assert "token=" in first.headers["location"]
+                # Token is in the fragment, not the query string (#68).
+                first_parsed = urlparse(first.headers["location"])
+                assert "token" in parse_qs(first_parsed.fragment)
+                assert "token" not in parse_qs(first_parsed.query)
 
                 # Same client instance — the FakeRedis is shared; state key was consumed.
                 second = await client.get(
@@ -359,6 +433,86 @@ class TestOAuthCallbackGet:
                 )
                 assert second.status_code == 302
                 assert "error=invalid_state" in second.headers["location"]
+
+
+class TestOAuthToTokenFlow:
+    """End-to-end: OAuth callback issues a token, then /auth/token/validate
+    accepts it (US#56 missing coverage).
+
+    The individual legs are tested elsewhere — callback→redirect above,
+    validate→200 in test_auth_endpoints.py — but nothing chains them. This
+    pins that the access token the callback mints is one the validate
+    endpoint actually accepts (same signing keypair, well-formed claims).
+    """
+
+    @pytest.mark.asyncio
+    async def test_callback_issued_token_passes_validate(
+        self,
+        client_factory: Any,
+        fake_user: User,
+    ) -> None:
+        state = "e2e-state-token"
+        seed = {
+            f"oauth_state:{state}": json.dumps(
+                {"provider": "google", "code_verifier": "pkce-verifier"}
+            ),
+        }
+
+        oauth_mock = MagicMock()
+        oauth_mock.exchange_code = AsyncMock(return_value={"access_token": "gtoken"})
+        oauth_mock.get_user_info = AsyncMock(
+            return_value=OAuthUserInfo(
+                provider="google",
+                provider_account_id="g-123",
+                email="mateo@example.com",
+                display_name="Mateo Test",
+                avatar_url=None,
+            )
+        )
+
+        with (
+            patch(
+                "src.app.routers.auth.get_oauth_provider",
+                return_value=oauth_mock,
+            ),
+            patch(
+                "src.app.routers.auth.find_or_create_oauth_user",
+                new_callable=AsyncMock,
+                return_value=OAuthUserResult(user=fake_user, is_new_user=False),
+            ),
+            patch(
+                "src.app.routers.auth.get_subscription_status",
+                new_callable=AsyncMock,
+                return_value="free",
+            ),
+            patch(
+                "src.app.routers.auth.store_refresh_token",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            async with await client_factory(seed) as client:
+                callback_resp = await client.get(
+                    "/auth/oauth/google/callback",
+                    params={"code": "abc123", "state": state},
+                )
+                assert callback_resp.status_code == 302
+                # Token is delivered in the URL fragment (#68).
+                fragment = parse_qs(urlparse(callback_resp.headers["location"]).fragment)
+                token = fragment["token"][0]
+                assert token
+
+                # Feed the freshly-issued token straight back to validate.
+                validate_resp = await client.get(
+                    "/auth/token/validate",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+
+        assert validate_resp.status_code == 200
+        data = validate_resp.json()
+        assert data["valid"] is True
+        assert data["user_id"] == str(fake_user.id)
+        assert data["email"] == fake_user.email
 
 
 class TestPostCallbackRemoved:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,260 @@
+"""Tests for auth-endpoint rate limiting — US #55.
+
+Covers the rate_limit service directly (limit-hit -> 429, fail-open paths,
+bucket isolation, toggle) and an integration check through the /auth/token/validate
+endpoint that a per-IP limit produces a 429 once the window budget is spent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, Request, status
+from httpx import ASGITransport, AsyncClient
+from redis.exceptions import RedisError
+
+from src.app.config import Settings
+from src.app.database import get_db_session, get_redis_optional
+from src.app.main import create_app
+from src.app.services.rate_limit import check_rate_limit, enforce_ip_rate_limit
+from src.app.services.token import create_access_token
+
+
+def _test_settings(**overrides: Any) -> Settings:
+    base: dict[str, Any] = {
+        "DATABASE_URL": "sqlite+aiosqlite:///:memory:",
+        "JWT_PRIVATE_KEY": "",
+        "JWT_PUBLIC_KEY": "",
+        "AUTH_RATE_LIMIT_ENABLED": True,
+        "AUTH_MAX_LOGIN_ATTEMPTS": 3,
+        "AUTH_LOCKOUT_DURATION_MINUTES": 15,
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+class _FakeRedis:
+    """In-memory async Redis stand-in implementing incr/expire for the limiter.
+
+    Tracks per-key TTL state so tests can assert a key is NOT left orphaned
+    without an expiry. `fail_expire_until` lets a test simulate a transient
+    Redis blip where EXPIRE raises for the first N calls then recovers.
+    """
+
+    def __init__(self, fail_expire_until: int = 0) -> None:
+        self._counts: dict[str, int] = {}
+        # key -> TTL seconds; absence means "no TTL set" (orphaned key).
+        self.ttls: dict[str, int] = {}
+        self.expire_calls: list[tuple[str, int]] = []
+        self._fail_expire_until = fail_expire_until
+        self._expire_attempts = 0
+
+    async def incr(self, key: str) -> int:
+        self._counts[key] = self._counts.get(key, 0) + 1
+        return self._counts[key]
+
+    async def expire(self, key: str, seconds: int) -> bool:
+        self._expire_attempts += 1
+        if self._expire_attempts <= self._fail_expire_until:
+            raise RedisError("transient blip during EXPIRE")
+        self.expire_calls.append((key, seconds))
+        self.ttls[key] = seconds
+        return True
+
+
+class _BrokenRedis:
+    """Async Redis stand-in whose incr always raises — exercises fail-open."""
+
+    async def incr(self, key: str) -> int:
+        raise RedisError("connection refused")
+
+    async def expire(self, key: str, seconds: int) -> bool:  # pragma: no cover
+        raise RedisError("connection refused")
+
+
+def _request_with_ip(ip: str) -> Request:
+    """Minimal ASGI scope Request carrying a client IP."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/auth/token/validate",
+        "headers": [],
+        "client": (ip, 12345),
+    }
+    return Request(scope)
+
+
+class TestCheckRateLimitService:
+    async def test_allows_up_to_limit_then_429(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=3)
+
+        # First 3 are allowed.
+        for _ in range(3):
+            await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+
+        # 4th exceeds the limit.
+        with pytest.raises(HTTPException) as exc_info:
+            await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        assert exc_info.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert "Retry-After" in (exc_info.value.headers or {})
+
+    async def test_expire_reasserted_on_every_call(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings()
+        window = settings.AUTH_LOCKOUT_DURATION_MINUTES * 60
+
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+
+        # EXPIRE is re-asserted on EVERY call (not just the first), each time with
+        # the full window length. This is what makes the limiter self-healing:
+        # an orphaned key (EXPIRE missed earlier) gets its TTL back next call.
+        assert redis.expire_calls == [("auth_rl:token:1.2.3.4", window)] * 3
+
+    async def test_no_orphaned_key_when_expire_fails_then_recovers(self) -> None:
+        """A transient EXPIRE failure must not permanently lock out an identifier.
+
+        Regression test for the INCR/EXPIRE split: if EXPIRE raises on the first
+        hit, the key was previously left with no TTL — once Redis recovered it
+        INCR'd forever and the identifier was permanently 429'd. With EXPIRE
+        re-asserted every call, the next successful call restores the TTL.
+        """
+        # EXPIRE fails on the first call (transient blip), succeeds afterwards.
+        redis = _FakeRedis(fail_expire_until=1)
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=5)
+        key = "auth_rl:token:1.2.3.4"
+        window = settings.AUTH_LOCKOUT_DURATION_MINUTES * 60
+
+        # First call: INCR succeeds, EXPIRE raises -> fails open (no exception),
+        # key is currently orphaned (count=1, no TTL).
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        assert key not in redis.ttls  # orphaned at this point
+
+        # Next call: EXPIRE recovers and is re-asserted -> key now has a TTL.
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        assert redis.ttls.get(key) == window  # self-healed, no permanent lockout
+
+    async def test_buckets_are_independent(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=2)
+
+        # Spend the budget on the "token" bucket.
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        with pytest.raises(HTTPException):
+            await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+
+        # A different bucket for the same identifier still has its full budget.
+        await check_rate_limit(redis, settings, bucket="refresh", identifier="1.2.3.4")
+
+    async def test_identifiers_are_independent(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=1)
+
+        await check_rate_limit(redis, settings, bucket="token", identifier="1.1.1.1")
+        with pytest.raises(HTTPException):
+            await check_rate_limit(redis, settings, bucket="token", identifier="1.1.1.1")
+
+        # Different IP — unaffected.
+        await check_rate_limit(redis, settings, bucket="token", identifier="2.2.2.2")
+
+    async def test_fail_open_when_redis_none(self) -> None:
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=1)
+        # Redis unavailable — never raises, regardless of how many calls.
+        for _ in range(10):
+            await check_rate_limit(None, settings, bucket="token", identifier="1.2.3.4")
+
+    async def test_fail_open_on_redis_error(self) -> None:
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=1)
+        broken = _BrokenRedis()
+        for _ in range(10):
+            await check_rate_limit(broken, settings, bucket="token", identifier="1.2.3.4")
+
+    async def test_disabled_toggle_skips_limiting(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings(AUTH_RATE_LIMIT_ENABLED=False, AUTH_MAX_LOGIN_ATTEMPTS=1)
+        for _ in range(10):
+            await check_rate_limit(redis, settings, bucket="token", identifier="1.2.3.4")
+        # Limiter never touched Redis.
+        assert redis.expire_calls == []
+
+    async def test_enforce_ip_rate_limit_keys_by_client_ip(self) -> None:
+        redis = _FakeRedis()
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=1)
+
+        await enforce_ip_rate_limit(_request_with_ip("9.9.9.9"), redis, settings, bucket="validate")
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_ip_rate_limit(
+                _request_with_ip("9.9.9.9"), redis, settings, bucket="validate"
+            )
+        assert exc_info.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+        # A request from a different IP is still allowed.
+        await enforce_ip_rate_limit(_request_with_ip("8.8.8.8"), redis, settings, bucket="validate")
+
+
+class TestRateLimitIntegration:
+    """End-to-end: /auth/token/validate returns 429 once the IP budget is spent."""
+
+    @pytest.fixture
+    async def client(self) -> AsyncGenerator[tuple[AsyncClient, Settings], None]:
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=3)
+        app = create_app()
+        app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+        # Shared FakeRedis across requests so the counter accumulates.
+        shared_redis = _FakeRedis()
+
+        async def _rl_redis() -> AsyncGenerator[Any, None]:
+            yield shared_redis
+
+        app.dependency_overrides[get_redis_optional] = _rl_redis
+
+        from src.app.config import get_settings
+
+        app.dependency_overrides[get_settings] = lambda: settings
+
+        transport = ASGITransport(app=app)  # type: ignore[arg-type]
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, settings
+
+    async def test_validate_endpoint_429_after_budget(
+        self, client: tuple[AsyncClient, Settings]
+    ) -> None:
+        ac, settings = client
+        token, _ = create_access_token(settings, uuid.uuid4(), "rl@example.com", ["reader"], "free")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # First AUTH_MAX_LOGIN_ATTEMPTS requests succeed.
+        for _ in range(settings.AUTH_MAX_LOGIN_ATTEMPTS):
+            resp = await ac.get("/auth/token/validate", headers=headers)
+            assert resp.status_code == 200
+
+        # Next one is rate limited.
+        resp = await ac.get("/auth/token/validate", headers=headers)
+        assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert "retry-after" in {k.lower() for k in resp.headers}
+
+    async def test_validate_endpoint_fail_open_without_redis(self) -> None:
+        """With Redis uninitialized (get_redis_optional yields None), no limiting."""
+        settings = _test_settings(AUTH_MAX_LOGIN_ATTEMPTS=1)
+        app = create_app()
+        app.dependency_overrides[get_db_session] = lambda: AsyncMock()
+
+        from src.app.config import get_settings
+
+        app.dependency_overrides[get_settings] = lambda: settings
+        # get_redis_optional is NOT overridden — yields None (Redis not initialized).
+
+        transport = ASGITransport(app=app)  # type: ignore[arg-type]
+        token, _ = create_access_token(settings, uuid.uuid4(), "rl@example.com", ["reader"], "free")
+        headers = {"Authorization": f"Bearer {token}"}
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            for _ in range(5):
+                resp = await ac.get("/auth/token/validate", headers=headers)
+                assert resp.status_code == 200

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -15,12 +15,12 @@ from src.app.services.keys import (
     get_public_key_jwk,
 )
 from src.app.services.token import (
-    _hash_token,
     create_access_token,
     create_refresh_token,
     decode_access_token,
     get_jwks,
 )
+from src.app.utils.crypto import hash_token
 
 
 def _test_settings() -> Settings:
@@ -179,9 +179,9 @@ class TestRefreshToken:
 
     def test_hash_is_deterministic(self) -> None:
         token = create_refresh_token()
-        assert _hash_token(token) == _hash_token(token)
+        assert hash_token(token) == hash_token(token)
 
     def test_different_tokens_different_hashes(self) -> None:
         t1 = create_refresh_token()
         t2 = create_refresh_token()
-        assert _hash_token(t1) != _hash_token(t2)
+        assert hash_token(t1) != hash_token(t2)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -24,13 +24,13 @@ from src.app.main import create_app
 from src.app.models.user import Base, User
 from src.app.models.verification_token import TokenType
 from src.app.services.verification import (
-    _hash_token,
     check_rate_limit,
     confirm_verification_token,
     create_verification_token,
     get_latest_verification_token,
     invalidate_existing_tokens,
 )
+from src.app.utils.crypto import hash_token
 
 # Generate a test RSA key pair (once per module)
 _test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -191,7 +191,7 @@ class TestCreateVerificationToken:
 
         latest = await get_latest_verification_token(db_session, test_user.id)
         assert latest is not None
-        assert latest.token_hash == _hash_token(raw_token)
+        assert latest.token_hash == hash_token(raw_token)
         assert latest.token_type == TokenType.email_verification
         assert latest.used_at is None
 
@@ -270,10 +270,10 @@ class TestInvalidateExistingTokens:
 class TestTokenHashing:
     def test_hash_deterministic(self) -> None:
         token = "test-token-123"
-        assert _hash_token(token) == _hash_token(token)
+        assert hash_token(token) == hash_token(token)
 
     def test_hash_different_tokens(self) -> None:
-        assert _hash_token("token-a") != _hash_token("token-b")
+        assert hash_token("token-a") != hash_token("token-b")
 
 
 # --- Endpoint integration tests ---


### PR DESCRIPTION
## What

Recovers OAuth-hardening + crypto-refactor content stranded on `deployments/phase-3/wave-10` — the wave-10→main merge never happened (see noorinalabs-main#520).

Brought forward selectively onto current `main` (NOT a wave-branch merge — main is newer on ci.yml / ghcr-publish.yml / uv.lock / pyproject.toml / docs, which were deliberately left untouched).

### Recovery units

1. **#54/#76 crypto refactor** — new `src/app/utils/crypto.py` `hash_token()` + `src/app/utils/__init__.py`. `token.py`, `routers/sessions.py`, `services/verification.py` now import it instead of carrying three inline `_hash_token` copies; unused `hashlib` imports dropped.
2. **#68 token-in-URL-fragment** — `_build_post_login_url` now delivers the access token in the URL `#fragment` (`#token=…`) instead of `?token=`, so it never leaks via the `Referer` header. Non-secret flags (`is_new_user`, `needs_verification`) stay as query params.
3. **#69 post-login-URL open-redirect validation** — `config.py` `_validate_oauth_post_login_url` + `_host_of`: relative-path or allowlisted-host only; rejects `javascript:`/`data:`, protocol-relative `//host`, and backslash bypasses; non-https rejected outside dev/test.
4. **#55 Redis auth rate limiting** — new `src/app/services/rate_limit.py`, `AUTH_RATE_LIMIT_ENABLED` config, `get_redis_optional` fail-open dependency in `database.py`, auth-endpoint wiring (`issue_token`, `refresh_token`, `validate_token`, `oauth_callback_get`), `.env.example` docs.
5. **Tests** — new `tests/test_rate_limit.py`, `tests/test_config_post_login_url.py`; `#70` OAuth GET callback fragment coverage in `tests/test_oauth_callback_get.py`; `_hash_token`→`hash_token` import swaps in `tests/test_token_service.py` and `tests/test_verification.py` (surgical — the #56 conftest refactor was deliberately NOT pulled).

## MERGE GATE

**Do not merge until isnad-graph's AuthCallbackPage fragment-parse recovery (ig#901) is merged** — the frontend must read tokens from the URL fragment before the backend starts sending them there, or OAuth login breaks.

## Verification

- `uv run ruff check .` ✅  ·  `uv run ruff format --check .` ✅  ·  `uv run mypy src` ✅
- `ENVIRONMENT=test uv run pytest` → **277 passed**

Refs noorinalabs-main#520
Recovers #68/#69/#55/#54/#76/#70 (stranded on wave-10)
