### PR TITLE
db(#520): recover subscriptions.user_id index (us#54)

### DIFF
--- a/alembic/versions/0041_add_subscriptions_user_id_index.py
+++ b/alembic/versions/0041_add_subscriptions_user_id_index.py
@@ -1,0 +1,33 @@
+"""Add index on subscriptions.user_id.
+
+The subscriptions table only had a partial unique index covering
+(user_id) WHERE plan='trial' AND status='active'. Equality lookups by
+user_id alone — get_current_subscription, get_subscription_status,
+start_trial, cancel_subscription — could not use it and fell back to a
+sequential scan. This adds a plain B-tree index on user_id.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-05-14
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0041"
+down_revision: str = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_subscriptions_user_id",
+        "subscriptions",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_subscriptions_user_id", table_name="subscriptions")

--- a/alembic/versions/MIGRATION_RANGES.md
+++ b/alembic/versions/MIGRATION_RANGES.md
@@ -10,6 +10,7 @@ each Phase 3 issue has a reserved range:
 | 0020–0029 | US #9  | Subscriptions         |
 | 0030–0039 | US #10 | 2FA / TOTP            |
 | 0040      | US #63 | Merge multi-heads     |
+| 0041      | US #54 | subscriptions.user_id index (tech-debt) |
 
 Name your migration files with the appropriate prefix, e.g.:
 `0010_add_verification_tokens.py` for US #8.

--- a/src/app/models/subscription.py
+++ b/src/app/models/subscription.py
@@ -39,7 +39,7 @@ class Subscription(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     plan: Mapped[SubscriptionPlan] = mapped_column(
         Enum(SubscriptionPlan, name="subscription_plan", create_constraint=False),


### PR DESCRIPTION
## What

Recovers the `subscriptions.user_id` index stranded on `deployments/phase-3/wave-10` (see noorinalabs-main#520).

The `subscriptions` table only had a *partial* unique index on `(user_id) WHERE plan='trial' AND status='active'`. Plain equality lookups by `user_id` (`get_current_subscription`, `get_subscription_status`, `start_trial`, `cancel_subscription`) could not use it and fell back to a sequential scan. This adds a plain B-tree index.

- `models/subscription.py`: `user_id` → `index=True`
- `alembic/versions/0041_add_subscriptions_user_id_index.py` (new)
- `MIGRATION_RANGES.md`: 0041 row

## Migration re-parenting

Checked main's actual head before importing: `alembic/versions/` head is **0040** (`0040_merge_multi_heads`, single head). Wave-10's `0041` already declares `down_revision = "0040"`, which IS main's current head — so it chains cleanly with **no re-numbering or re-parenting required**. Verified post-apply:

```
$ alembic heads
0041 (head)
```

Single linear head, no multi-head.

## Verification

- `uv run ruff check .` ✅  ·  `uv run ruff format --check .` ✅  ·  `uv run mypy src` ✅
- `alembic heads` → single head `0041`
- `ENVIRONMENT=test uv run pytest` → **249 passed**

Refs noorinalabs-main#520
Recovers #54 (stranded on wave-10)
