### PR TITLE
chore(#520): recover stranded docs/test/infra hygiene

### DIFF
--- a/.claude/team/charter.md
+++ b/.claude/team/charter.md
@@ -1,5 +1,11 @@
 # Team Charter — noorinalabs-user-service
 
+## Repository Context
+
+`noorinalabs-user-service` is a **child repository of the `noorinalabs-main` organization repo**. It is an independent git repository (own branches, PRs, CI) that is normally cloned beneath `noorinalabs-main/`, but it can also be cloned standalone.
+
+Org-wide rules live once in the `noorinalabs-main` charter. The "Shared Rules" links below point to the canonical copies via GitHub URLs so they resolve from a standalone clone, a nested clone, or a worktree checkout alike. When working inside `noorinalabs-main`, the same docs are on disk at `noorinalabs-main/.claude/team/charter/`.
+
 ## Purpose
 
 All work on the noorinalabs-user-service repository is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
@@ -14,18 +20,18 @@ All work on the noorinalabs-user-service repository is executed through a simula
 
 ## Shared Rules (Org Charter)
 
-The following rules are defined once in the org charter and apply to all repos. Agents MUST load the relevant sub-doc when performing that activity.
+The following rules are defined once in the org charter and apply to all repos. Agents MUST load the relevant sub-doc when performing that activity. Links point to the canonical copies in `noorinalabs-main` (see Repository Context above).
 
 | Topic | Reference |
 |-------|-----------|
-| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](../../../.claude/team/charter/issues.md) |
-| Branching rules, deployment branches, worktree cleanup | [Org § Branching](../../../.claude/team/charter/branching.md) |
-| Commit identity, co-author trailers | [Org § Commits](../../../.claude/team/charter/commits.md) |
-| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](../../../.claude/team/charter/pull-requests.md) |
-| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](../../../.claude/team/charter/agents.md) |
-| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](../../../.claude/team/charter/hooks.md) |
-| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](../../../.claude/team/charter/tech-decisions.md) |
-| Cross-repo communication protocol | [Org § Communication](../../../.claude/team/charter/communication.md) |
+| Issue comments, reply protocol, delegation, assignment, hygiene | [Org § Issues](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/issues.md) |
+| Branching rules, deployment branches, worktree cleanup | [Org § Branching](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/branching.md) |
+| Commit identity, co-author trailers | [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) |
+| PR workflow, CI enforcement, consolidated PRs, cross-PR deps | [Org § Pull Requests](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/pull-requests.md) |
+| Agent naming, lifecycle, hub-and-spoke, team lifecycle | [Org § Agents](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/agents.md) |
+| Hooks (validate identity, block --no-verify, block git config, auto env test, validate labels) | [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) |
+| Tech preferences, debate, tie-breaking (LCA) | [Org § Tech Decisions](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/tech-decisions.md) |
+| Cross-repo communication protocol | [Org § Communication](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/communication.md) |
 
 ## Org Chart
 
@@ -94,11 +100,11 @@ graph TD
 | Mateo Salazar | `Mateo Salazar` | `parametrization+Mateo.Salazar@gmail.com` |
 | Idris Yusuf | `Idris Yusuf` | `parametrization+Idris.Yusuf@gmail.com` |
 
-See [Org § Commits](../../../.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
+See [Org § Commits](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/commits.md) for the commit format, co-author trailers, and identity rules.
 
 ## Automated Enforcement (Git Hooks)
 
-Commit identity, `--no-verify` blocking, and `git config` blocking are enforced via Claude Code hooks defined at the org level (`noorinalabs-main/.claude/settings.json`). See [Org § Hooks](../../../.claude/team/charter/hooks.md) for details.
+Commit identity, `--no-verify` blocking, and `git config` blocking are enforced via Claude Code hooks defined at the org level (`noorinalabs-main/.claude/settings.json`). See [Org § Hooks](https://github.com/noorinalabs/noorinalabs-main/blob/main/.claude/team/charter/hooks.md) for details.
 
 ## Steady-State Goal
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,60 @@
+# Python virtual environment — LOAD-BEARING.
+# Without this, `COPY . .` in the runtime stage pulls a host developer's
+# local `.venv/` (from `uv sync`) into the build context and overwrites the
+# builder-stage venv copied via `COPY --from=builder /app/.venv`. The host
+# venv's entry-point scripts (alembic, uvicorn) have shebangs pointing at the
+# developer's absolute host path, so they fail inside the container with
+# `sh: ... not found`. See issue #79.
+.venv/
+venv/
+env/
+
+# Python caches / compiled artefacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+
+# Test / coverage artefacts
+.coverage
+coverage.xml
+htmlcov/
+
+# Git / CI / tooling — not needed in the image, only bloats the build context
+.git/
+.gitignore
+.github/
+.pre-commit-config.yaml
+
+# Local dev compose / docker files — not needed inside the image
+docker-compose.dev.yml
+docker-compose.override.yml
+Dockerfile
+.dockerignore
+
+# Local environment files — never bake secrets into an image
+.env
+.env.*
+!.env.example
+
+# Editor / OS cruft
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Logs / temp
+*.log
+tmp/
+temp/
+.cache/
+
+# Agent / harness workdir — never belongs in a build context
+.claude/

--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,35 @@
+name: Auto-close issues
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close referenced issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const matches = body.matchAll(/[Cc]loses?\s+#(\d+)/g);
+            for (const match of matches) {
+              const issue_number = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by PR #${context.payload.pull_request.number} merged into \`${context.payload.pull_request.base.ref}\`.`,
+              });
+            }

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -119,11 +119,11 @@ erDiagram
         timestamptz created_at
     }
 
-    users ||--o{ user_roles : "has roles"
+    users ||--o{ user_roles : "holds role (user_id)"
+    users ||--o{ user_roles : "granted role (granted_by)"
     roles ||--o{ user_roles : "assigned to"
     users ||--o{ sessions : "has sessions"
     users ||--o{ subscriptions : "has subscription"
     users ||--o{ verification_tokens : "has tokens"
     users ||--o{ oauth_accounts : "linked accounts"
-    users ||--o{ user_roles : "grants (granted_by)"
 ```


### PR DESCRIPTION
## What

Recovers stranded docs / infra hygiene from `deployments/phase-3/wave-10` (see noorinalabs-main#520).

- **#21** `docs/schema.md` — disambiguate the two `users`→`user_roles` ER relations (`holds role` via `user_id` vs `granted role` via `granted_by`).
- **#15** `.claude/team/charter.md` — add a Repository Context section; switch the org-charter "Shared Rules" links from relative `../../../` paths to canonical GitHub URLs so they resolve from a standalone clone, nested clone, or worktree alike.
- **#79** `.dockerignore` — keep the Docker build context lean.
- `.github/workflows/auto-close-issues.yml` — close `Closes #N`-referenced issues on PR merge (owner-approved org-wide, recovered from commit a8e3e58).

## Verification

- `actionlint` clean on the new workflow AND repo-wide (no new debt)
- Pre-commit ⇄ CI sync-drift gate passes (no new unmirrored CI check)
- `cspell` clean on the changed markdown
- `uv run ruff format --check .` ✅  ·  `uv run mypy src` ✅  ·  `pytest` → **249 passed**

Refs noorinalabs-main#520
Recovers #21/#15/#79 (stranded on wave-10)
