### PR TITLE
fix(config): build connection URLs from separate env vars (#65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,28 @@
 # Database
+# Two ways to configure the connection:
+#   (a) DATABASE_URL — single pre-composed URL (local-dev default below).
+#   (b) Separate component vars (PREFERRED in deploy) — set DATABASE_HOST and the
+#       app builds the URL with the password URL-encoded, so passwords containing
+#       `/`, `+`, `=`, `@`, etc. can never corrupt the URL (#65). When DATABASE_HOST
+#       is set the component vars win and DATABASE_URL is ignored.
 DATABASE_URL=postgresql+asyncpg://user_service:user_service_dev@localhost:5433/user_service
+# DATABASE_HOST=user-postgres
+# DATABASE_PORT=5432
+# DATABASE_USER=user_service
+# DATABASE_PASSWORD=<raw-value-no-encoding-needed>
+# DATABASE_NAME=user_service
+# DATABASE_DRIVER=postgresql+asyncpg
 
 # Redis
+# Same two-way config as the database. Set REDIS_HOST to use the component vars
+# (PREFERRED in deploy — password is URL-encoded in-app). When REDIS_HOST is set
+# the component vars win and REDIS_URL is ignored.
 REDIS_URL=redis://localhost:6380/0
+# REDIS_HOST=user-redis
+# REDIS_PORT=6379
+# REDIS_PASSWORD=<raw-value-no-encoding-needed>
+# REDIS_DB=0
+# REDIS_TLS=false
 
 # JWT (RS256) — leave empty to auto-generate dev keys
 JWT_PRIVATE_KEY=

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -19,7 +19,7 @@ def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
     settings = get_settings()
     context.configure(
-        url=settings.DATABASE_URL,
+        url=settings.effective_database_url,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -37,7 +37,7 @@ def do_run_migrations(connection: object) -> None:
 async def run_migrations_online() -> None:
     """Run migrations in 'online' mode with async engine."""
     settings = get_settings()
-    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    engine = create_async_engine(settings.effective_database_url, pool_pre_ping=True)
     async with engine.connect() as connection:
         await connection.run_sync(do_run_migrations)
     await engine.dispose()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,9 +1,10 @@
 from functools import lru_cache
 from typing import Self
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
-from pydantic import field_validator, model_validator
+from pydantic import computed_field, field_validator, model_validator
 from pydantic_settings import BaseSettings
+from sqlalchemy import URL
 
 _ALLOWED_OVERRIDE_SCHEMES = frozenset({"http", "https"})
 _PROD_LIKE_ENVIRONMENTS = frozenset({"production", "staging"})
@@ -25,13 +26,36 @@ class Settings(BaseSettings):
     # Deployment environment — gates security-sensitive settings
     ENVIRONMENT: str = "development"
 
-    # Database
+    # Database — preferred config path is the separate component vars below
+    # (DATABASE_HOST/PORT/USER/PASSWORD/NAME). When any component is set, the
+    # connection URL is built in-app via sqlalchemy.URL.create, which URL-encodes
+    # the password — so passwords containing `/`, `+`, `=`, `@`, etc. are handled
+    # safely (#65). DATABASE_URL is retained as a backward-compatible fallback and
+    # as the local-dev default; it is used verbatim only when no component is set.
     DATABASE_URL: str = (
         "postgresql+asyncpg://user_service:user_service_dev@localhost:5433/user_service"
     )
+    DATABASE_HOST: str | None = None
+    DATABASE_PORT: int = 5432
+    DATABASE_USER: str | None = None
+    DATABASE_PASSWORD: str | None = None
+    DATABASE_NAME: str | None = None
+    # Driver scheme used when building the URL from components.
+    DATABASE_DRIVER: str = "postgresql+asyncpg"
 
-    # Redis
+    # Redis — preferred config path is the separate component vars below
+    # (REDIS_HOST/PORT/PASSWORD/DB). When REDIS_HOST is set, the connection URL is
+    # built in-app with the password URL-encoded via urllib.parse.quote — so a
+    # base64 password containing `/` no longer terminates the URL authority and
+    # crashes urlparse at startup (#65). REDIS_URL is the backward-compatible
+    # fallback / local-dev default, used verbatim only when REDIS_HOST is unset.
     REDIS_URL: str = "redis://localhost:6380/0"
+    REDIS_HOST: str | None = None
+    REDIS_PORT: int = 6379
+    REDIS_PASSWORD: str | None = None
+    REDIS_DB: int = 0
+    # Set true to use rediss:// (TLS) when building the URL from components.
+    REDIS_TLS: bool = False
 
     # JWT (RS256)
     JWT_PRIVATE_KEY: str = ""
@@ -120,6 +144,46 @@ class Settings(BaseSettings):
     AUTH_OAUTH_REFRESH_COOKIE_SECURE: bool = True
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_database_url(self) -> str:
+        """The Postgres connection URL the app should actually connect with.
+
+        When DATABASE_HOST is set, build the URL from the component vars via
+        ``sqlalchemy.URL.create`` (which URL-encodes the password), so a password
+        with URL-unsafe characters can never corrupt the URL. Otherwise fall back
+        to DATABASE_URL verbatim (backward compat / local-dev default).
+        """
+        if self.DATABASE_HOST is None:
+            return self.DATABASE_URL
+        return URL.create(
+            drivername=self.DATABASE_DRIVER,
+            username=self.DATABASE_USER,
+            password=self.DATABASE_PASSWORD,
+            host=self.DATABASE_HOST,
+            port=self.DATABASE_PORT,
+            database=self.DATABASE_NAME,
+        ).render_as_string(hide_password=False)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_redis_url(self) -> str:
+        """The Redis connection URL the app should actually connect with.
+
+        When REDIS_HOST is set, build ``redis(s)://[:<encoded-password>@]host:port/db``
+        with the password percent-encoded via ``urllib.parse.quote`` (so `/`, `@`,
+        `:`, `#`, etc. survive urlparse). Otherwise fall back to REDIS_URL verbatim
+        (backward compat / local-dev default).
+        """
+        if self.REDIS_HOST is None:
+            return self.REDIS_URL
+        scheme = "rediss" if self.REDIS_TLS else "redis"
+        auth = ""
+        if self.REDIS_PASSWORD:
+            # safe="" so every URL-reserved char in the password is encoded.
+            auth = f":{quote(self.REDIS_PASSWORD, safe='')}@"
+        return f"{scheme}://{auth}{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
     @field_validator("ENVIRONMENT")
     @classmethod

--- a/src/app/database.py
+++ b/src/app/database.py
@@ -21,7 +21,7 @@ async def init_db() -> None:
     """Initialize the database engine and session factory."""
     global _engine, _async_session_factory
     settings = get_settings()
-    _engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    _engine = create_async_engine(settings.effective_database_url, pool_pre_ping=True)
     _async_session_factory = async_sessionmaker(_engine, expire_on_commit=False)
 
 
@@ -29,7 +29,7 @@ async def init_redis() -> None:
     """Initialize the Redis client."""
     global _redis_client
     settings = get_settings()
-    _redis_client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+    _redis_client = Redis.from_url(settings.effective_redis_url, decode_responses=False)
 
 
 async def close_db() -> None:

--- a/tests/test_config_connection_urls.py
+++ b/tests/test_config_connection_urls.py
@@ -1,0 +1,118 @@
+"""Connection-URL construction from separate component env vars (#65).
+
+The bug: a base64 ``USER_REDIS_PASSWORD`` containing ``/`` was string-interpolated
+into ``redis://:<pw>@host:6379/0``; the first ``/`` terminated the URL authority
+and ``urlparse`` crashed reading ``host:port`` at startup. The fix accepts separate
+component env vars and builds the URL in-app with the password URL-encoded.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+from redis.asyncio import Redis
+from sqlalchemy.engine import make_url
+
+from src.app.config import Settings
+
+# Every URL-reserved character that previously could corrupt a connection URL.
+URL_UNSAFE_PASSWORDS = [
+    "tW/Q37WBF/HilCx8Lls4o/J7UKrKsoA7jTI5o/Jd2tk=",  # the real #65 repro value
+    "p/a/s/s",
+    "pa+ss",
+    "pass==",
+    "p@ss",
+    "pa:ss",
+    "pa#ss",
+    "pa?ss",
+    "pa%ss",
+    "a/b+c=d@e:f#g?h%i",  # all of them at once
+]
+
+
+class TestRedisUrlFromComponents:
+    def test_falls_back_to_redis_url_when_host_unset(self) -> None:
+        s = Settings(REDIS_URL="redis://localhost:6380/2")
+        assert s.effective_redis_url == "redis://localhost:6380/2"
+
+    def test_components_win_over_redis_url(self) -> None:
+        s = Settings(
+            REDIS_URL="redis://localhost:6380/0",
+            REDIS_HOST="user-redis",
+            REDIS_PORT=6379,
+            REDIS_PASSWORD="simplepass",
+            REDIS_DB=1,
+        )
+        parsed = urlparse(s.effective_redis_url)
+        assert parsed.scheme == "redis"
+        assert parsed.hostname == "user-redis"
+        assert parsed.port == 6379
+        assert parsed.path == "/1"
+
+    def test_no_password_omits_authority(self) -> None:
+        s = Settings(REDIS_HOST="user-redis", REDIS_PORT=6379, REDIS_DB=0)
+        assert s.effective_redis_url == "redis://user-redis:6379/0"
+
+    def test_tls_uses_rediss_scheme(self) -> None:
+        s = Settings(REDIS_HOST="user-redis", REDIS_TLS=True)
+        assert urlparse(s.effective_redis_url).scheme == "rediss"
+
+    @pytest.mark.parametrize("password", URL_UNSAFE_PASSWORDS)
+    def test_url_unsafe_password_parses_and_roundtrips(self, password: str) -> None:
+        """Host/port must parse correctly and the redis client must recover the raw password."""
+        s = Settings(
+            REDIS_HOST="user-redis",
+            REDIS_PORT=6379,
+            REDIS_PASSWORD=password,
+            REDIS_DB=0,
+        )
+        url = s.effective_redis_url
+        # urlparse must not choke on host:port (the original #65 crash).
+        parsed = urlparse(url)
+        assert parsed.hostname == "user-redis"
+        assert parsed.port == 6379
+        # The redis client must decode the password back to the raw value.
+        client = Redis.from_url(url, decode_responses=False)
+        kwargs = client.connection_pool.connection_kwargs
+        assert kwargs["host"] == "user-redis"
+        assert kwargs["port"] == 6379
+        assert kwargs["password"] == password
+
+
+class TestDatabaseUrlFromComponents:
+    def test_falls_back_to_database_url_when_host_unset(self) -> None:
+        url = "postgresql+asyncpg://u:p@localhost:5433/db"
+        s = Settings(DATABASE_URL=url)
+        assert s.effective_database_url == url
+
+    def test_components_win_over_database_url(self) -> None:
+        s = Settings(
+            DATABASE_URL="postgresql+asyncpg://u:p@localhost:5433/db",
+            DATABASE_HOST="user-postgres",
+            DATABASE_PORT=5432,
+            DATABASE_USER="user_service",
+            DATABASE_PASSWORD="simplepass",
+            DATABASE_NAME="user_service",
+        )
+        parsed = make_url(s.effective_database_url)
+        assert parsed.drivername == "postgresql+asyncpg"
+        assert parsed.host == "user-postgres"
+        assert parsed.port == 5432
+        assert parsed.username == "user_service"
+        assert parsed.database == "user_service"
+
+    @pytest.mark.parametrize("password", URL_UNSAFE_PASSWORDS)
+    def test_url_unsafe_password_parses_and_roundtrips(self, password: str) -> None:
+        s = Settings(
+            DATABASE_HOST="user-postgres",
+            DATABASE_PORT=5432,
+            DATABASE_USER="user_service",
+            DATABASE_PASSWORD=password,
+            DATABASE_NAME="user_service",
+        )
+        # SQLAlchemy must parse the URL back and recover the raw password.
+        parsed = make_url(s.effective_database_url)
+        assert parsed.host == "user-postgres"
+        assert parsed.port == 5432
+        assert parsed.username == "user_service"
+        assert parsed.database == "user_service"
+        assert parsed.password == password


### PR DESCRIPTION
## Summary

`user-service` crashed at startup with `ValueError: Port could not be cast to integer value as 'tW'` because `REDIS_URL` was built by string-interpolating `USER_REDIS_PASSWORD` (a base64 value containing `/`) into `redis://:<pw>@user-redis:6379/0`. The first `/` in the password terminated the URL authority, so `urlparse` read `:tW` as `host:port`.

This PR makes the app accept **separate connection-component env vars** as the preferred config path and builds the URLs in-app with the password URL-encoded, so a password containing any URL-reserved character can never corrupt the URL.

### Changes
- `config.py`: new component fields
  - Redis: `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` / `REDIS_DB` (+ `REDIS_TLS`)
  - Database: `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_USER` / `DATABASE_PASSWORD` / `DATABASE_NAME` (+ `DATABASE_DRIVER`)
  - Computed properties `effective_redis_url` / `effective_database_url`:
    - Redis URL built with `urllib.parse.quote(safe="")` on the password.
    - Database URL built via `sqlalchemy.URL.create` (URL-encodes the password).
    - Both **fall back** to `REDIS_URL` / `DATABASE_URL` verbatim when the host var is unset → fully backward-compatible, unchanged local-dev default.
- `database.py` and `alembic/env.py` now consume the `effective_*` properties.
- `.env.example` documents the new component vars (commented; URL form remains the default).

### Backward compatibility
No behavior change unless `REDIS_HOST` / `DATABASE_HOST` is set. Existing deploys using the URL env vars are unaffected.

## Test Plan
- New `tests/test_config_connection_urls.py` (26 cases): passwords containing `/ + = @ : # ? %` (including the real repro value) — asserts host/port parse correctly and the raw password round-trips back out of both the redis client (`Redis.from_url`) and the SQLAlchemy URL (`make_url`). Plus fallback + component-precedence + TLS + no-password cases.
- `uv run ruff check` ✅ · `uv run ruff format --check` ✅ · `uv run mypy src/` ✅ · full `pytest` suite **303 passed** ✅ (locally; CI authoritative).

## Follow-up (NOT this PR)
- **noorinalabs-deploy**: rewrite `compose/docker-compose.prod.yml` env list for `user-postgres` + `user-redis` to pass the separate component vars instead of the pre-composed URL. Until that lands, this PR is backward-compatible (URL fallback unchanged).
- **Interim unblock** (owner): rotate `USER_REDIS_PASSWORD` to a URL-safe value.
- **Sibling**: isnad-graph api has the same pattern for its own postgres/redis — file as sibling.

Closes #65

Co-Authored-By: Mateo Salazar <parametrization+Mateo.Salazar@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
