### PR TITLE
feat(subscriptions): GET /me returns 200/null instead of 404 (#74)

### DIFF
--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -1428,7 +1428,7 @@
         ]
       },
       "get": {
-        "description": "Get the current user's subscription.",
+        "description": "Get the current user's subscription, or null if they have none.\n\nReturns 200 with a `null` body (not 404) when the user has no subscription:\nthe user resource exists and \"no subscription / free tier\" is a normal state,\nnot an error. Frontend consumers treat null as \"show the pricing CTA\" rather\nthan having to special-case an HTTP error (#74).",
         "operationId": "get_my_subscription_api_v1_subscriptions_me_get",
         "parameters": [
           {
@@ -1446,7 +1446,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubscriptionRead"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/SubscriptionRead"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Get My Subscription Api V1 Subscriptions Me Get"
                 }
               }
             },

--- a/src/app/routers/subscriptions.py
+++ b/src/app/routers/subscriptions.py
@@ -20,18 +20,21 @@ from src.app.services import subscription as sub_svc
 router = APIRouter(prefix="/api/v1/subscriptions", tags=["subscriptions"])
 
 
-@router.get("/me", response_model=SubscriptionRead)
+@router.get("/me", response_model=SubscriptionRead | None)
 async def get_my_subscription(
     current_user: CurrentUserDep,
     db: DbDep,
-) -> SubscriptionRead:
-    """Get the current user's subscription."""
+) -> SubscriptionRead | None:
+    """Get the current user's subscription, or null if they have none.
+
+    Returns 200 with a `null` body (not 404) when the user has no subscription:
+    the user resource exists and "no subscription / free tier" is a normal state,
+    not an error. Frontend consumers treat null as "show the pricing CTA" rather
+    than having to special-case an HTTP error (#74).
+    """
     sub = await sub_svc.get_current_subscription(db, current_user.id)
     if sub is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No subscription found",
-        )
+        return None
     return SubscriptionRead.model_validate(sub)
 
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -247,11 +247,14 @@ class TestSubscriptionService:
 
 class TestGetMySubscription:
     @pytest.mark.asyncio
-    async def test_no_subscription_returns_404(
+    async def test_no_subscription_returns_200_null(
         self, client: AsyncClient, regular_user: User
     ) -> None:
+        # No subscription is a normal state (free tier), not an error: 200 + null
+        # body, not 404 (#74).
         resp = await client.get("/api/v1/subscriptions/me", headers=_auth_header(regular_user))
-        assert resp.status_code == 404
+        assert resp.status_code == 200
+        assert resp.json() is None
 
     @pytest.mark.asyncio
     async def test_returns_subscription(


### PR DESCRIPTION
## Summary

`GET /api/v1/subscriptions/me` returned **404 `{"detail":"No subscription found"}`** when a logged-in user had no subscription. The user resource exists; only the subscription doesn't — "no subscription / free tier" is a normal state, not an HTTP error. The 404 forced frontend consumers (isnad-graph's `fetchJson` throws on `!res.ok`) to special-case a normal state as an exception, compounding with TanStack Query retries.

### Changes
- `routers/subscriptions.py`: `/me` `response_model` → `SubscriptionRead | None`; returns `None` (200 + `null` body) when there is no subscription.
  - Other routes that 404 on missing subscription (admin `GET /{user_id}`, `DELETE /me`) are **unchanged** — out of scope per the issue.
- `docs/openapi-snapshot.json` regenerated so the `openapi-snapshot-drift` CI gate stays green (`/me` 200 schema is now `anyOf[SubscriptionRead, null]`).
- Test updated: no-subscription `/me` now asserts **200 + null body**.

## Test Plan
- `tests/test_subscriptions.py::TestGetMySubscription::test_no_subscription_returns_200_null` — asserts 200 and `resp.json() is None`.
- `uv run ruff check` ✅ · `uv run ruff format --check` ✅ · `uv run mypy src/` ✅ · full `pytest` suite **277 passed** ✅ (locally; CI authoritative).

## Follow-up (NOT this PR)
- **noorinalabs-isnad-graph**: `fetchSubscription` return type becomes `SubscriptionResponse | null`; `UserMenu` / `PricingPage` handle `null` as "no subscription, show pricing CTA". Land this PR first.

Closes #74

Co-Authored-By: Mateo Salazar <parametrization+Mateo.Salazar@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
