### PR TITLE
feat(bootstrap): idempotent admin grant for the bootstrap account (us#159)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev setup-hooks infra infra-down test lint format typecheck check migrate migrate-new migrate-down openapi-snapshot
+.PHONY: setup dev setup-hooks infra infra-down test lint format typecheck check migrate migrate-new migrate-down openapi-snapshot bootstrap-admin
 
 # Setup
 setup:
@@ -46,3 +46,10 @@ migrate-down:
 # API surface
 openapi-snapshot:
 	uv run python scripts/generate_openapi_snapshot.py
+
+# Bootstrap: idempotently grant admin to the bootstrap account (us#159).
+# Account creation is OAuth-only — the owner must log in once via Google OAuth
+# as the bootstrap email first; this only ELEVATES that existing account.
+# Override the target via BOOTSTRAP_ADMIN_EMAIL (default parametrization@gmail.com).
+bootstrap-admin:
+	uv run python scripts/bootstrap_admin.py

--- a/scripts/bootstrap_admin.py
+++ b/scripts/bootstrap_admin.py
@@ -1,0 +1,242 @@
+"""Idempotently grant the ``admin`` role to the bootstrap account.
+
+Why this exists (us#159)
+------------------------
+The ``admin`` ROLE is seeded by alembic ``0001_initial_schema`` but **no user
+is granted it**. Every user-service admin endpoint requires an admin JWT, and
+the isnad-graph admin panels (user-mgmt, data, reset) all sit behind that JWT —
+so without a seeded admin they 401/403 for everyone. This is a chicken-and-egg
+bootstrap: granting admin normally requires an admin to call the grant endpoint.
+
+What this does (and deliberately does NOT do)
+---------------------------------------------
+This script ONLY elevates an account that **already exists** — it finds the
+bootstrap user by email and assigns the ``admin`` role IF NOT ALREADY ASSIGNED.
+
+It never creates an account and never sets a credential. Account creation in
+this service is OAuth-only (``find_or_create_oauth_user``); there is no
+password-registration / password-login path, so a synthetic "bootstrap admin"
+account with a hardcoded password would be unusable. The supported flow is:
+
+    1. The owner logs in once via Google OAuth as the bootstrap email
+       (default: ``parametrization@gmail.com``). That creates the user row.
+    2. Run this script (locally, or as a post-deploy step). It grants admin.
+
+Idempotency / safety
+--------------------
+- Running twice = exactly one grant (the second run reports ``already_admin``).
+- No-op (exit 0) when the user does not exist yet — so it can run unattended in
+  a deploy *before* the owner has ever logged in without crashing the deploy.
+  Pass ``--require-user`` to make an absent user a hard error (exit 1) instead.
+- ``BootstrapError`` (exit 1) is reserved for genuine misconfiguration — e.g.
+  the ``admin`` role is missing, which means the DB was never migrated.
+
+Usage
+-----
+    # Defaults: email from BOOTSTRAP_ADMIN_EMAIL (or parametrization@gmail.com),
+    # database URL from the app settings (DATABASE_URL / DATABASE_* components).
+    python scripts/bootstrap_admin.py
+
+    # Explicit overrides:
+    python scripts/bootstrap_admin.py \
+        --email someone@example.com \
+        --database-url postgresql+asyncpg://user:pass@host:5432/user_service
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.app.models.role import Role, UserRole
+from src.app.models.user import User
+
+log = logging.getLogger("bootstrap_admin")
+
+# The account elevated by default. This is an *identifier*, not a credential —
+# it selects which already-existing account to grant admin to. Override with
+# --email or the BOOTSTRAP_ADMIN_EMAIL env var.
+DEFAULT_ADMIN_EMAIL = "parametrization@gmail.com"
+
+ADMIN_ROLE_NAME = "admin"
+
+GrantStatus = Literal["granted", "already_admin", "user_not_found"]
+
+
+class BootstrapError(RuntimeError):
+    """A genuine misconfiguration that should fail loudly (non-zero exit).
+
+    Distinct from the benign ``user_not_found`` no-op: this signals the database
+    is not in a usable state (e.g. the ``admin`` role is missing because
+    migrations never ran).
+    """
+
+
+@dataclass
+class GrantResult:
+    status: GrantStatus
+    email: str
+    user_id: uuid.UUID | None = None
+
+
+async def grant_admin(db: AsyncSession, email: str) -> GrantResult:
+    """Grant ``admin`` to the user with ``email`` if not already granted.
+
+    Pure, idempotent, and DB-agnostic (works on SQLite or Postgres):
+    - returns ``user_not_found`` (no write) when no such user exists;
+    - returns ``already_admin`` (no write) when the grant already exists;
+    - otherwise inserts the ``user_roles`` row and returns ``granted``.
+
+    Raises :class:`BootstrapError` if the ``admin`` role itself is missing — the
+    role is created by migration ``0001`` so its absence means an unmigrated DB.
+    """
+    user = (await db.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if user is None:
+        return GrantResult(status="user_not_found", email=email)
+
+    admin_role = (
+        await db.execute(select(Role).where(Role.name == ADMIN_ROLE_NAME))
+    ).scalar_one_or_none()
+    if admin_role is None:
+        msg = (
+            f"The {ADMIN_ROLE_NAME!r} role does not exist — the database has not "
+            "been migrated (expected from alembic 0001_initial_schema). Run "
+            "`make migrate` before bootstrapping the admin."
+        )
+        raise BootstrapError(msg)
+
+    existing = (
+        await db.execute(
+            select(UserRole).where(
+                UserRole.user_id == user.id,
+                UserRole.role_id == admin_role.id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return GrantResult(status="already_admin", email=email, user_id=user.id)
+
+    # granted_by is left NULL: this is the *first* admin, granted by the system
+    # bootstrap rather than by an existing administrator. The FK is nullable
+    # (ON DELETE SET NULL), so NULL is the correct "no granting admin" sentinel.
+    db.add(UserRole(user_id=user.id, role_id=admin_role.id, granted_by=None))
+    await db.commit()
+    return GrantResult(status="granted", email=email, user_id=user.id)
+
+
+def _to_async_url(database_url: str) -> str:
+    """Normalise a connection URL to the asyncpg driver this script uses.
+
+    Accepts the app default (``postgresql+asyncpg://``), a bare
+    ``postgresql://``, or a sync ``postgresql+psycopg2://`` URL (e.g. one a
+    human copied from psql) and returns an asyncpg URL. Non-postgres URLs (such
+    as ``sqlite+aiosqlite://`` used by tests) are returned unchanged.
+    """
+    if database_url.startswith("postgresql+asyncpg://"):
+        return database_url
+    if database_url.startswith("postgresql+psycopg2://"):
+        return database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+    if database_url.startswith("postgresql://"):
+        return database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return database_url
+
+
+async def run(database_url: str, email: str) -> GrantResult:
+    """Open an async engine/session against ``database_url`` and grant admin."""
+    engine = create_async_engine(_to_async_url(database_url), echo=False)
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            return await grant_admin(session, email)
+    finally:
+        await engine.dispose()
+
+
+def _resolve_email(arg_email: str | None) -> str:
+    if arg_email:
+        return arg_email
+    return os.environ.get("BOOTSTRAP_ADMIN_EMAIL") or DEFAULT_ADMIN_EMAIL
+
+
+def _resolve_database_url(arg_url: str | None) -> str:
+    if arg_url:
+        return arg_url
+    # Reuse the app's single source of truth (reads DATABASE_URL or the
+    # DATABASE_* component vars). Imported lazily so test collection never
+    # triggers settings validation.
+    from src.app.config import get_settings
+
+    return get_settings().effective_database_url
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Idempotently grant the admin role to the bootstrap account.",
+    )
+    parser.add_argument(
+        "--email",
+        default=None,
+        help=(
+            "Email of the account to grant admin. Defaults to "
+            "$BOOTSTRAP_ADMIN_EMAIL or " + DEFAULT_ADMIN_EMAIL
+        ),
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Postgres connection URL. Defaults to the app settings (DATABASE_URL).",
+    )
+    parser.add_argument(
+        "--require-user",
+        action="store_true",
+        help="Exit non-zero if the target user does not exist (default: no-op exit 0).",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable DEBUG logging.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    email = _resolve_email(args.email)
+    database_url = _resolve_database_url(args.database_url)
+
+    try:
+        result = asyncio.run(run(database_url, email))
+    except BootstrapError as exc:
+        log.error("%s", exc)
+        return 1
+
+    if result.status == "granted":
+        log.info("Granted admin to %s (user_id=%s).", result.email, result.user_id)
+        return 0
+    if result.status == "already_admin":
+        log.info("%s is already an admin (user_id=%s) — no change.", result.email, result.user_id)
+        return 0
+
+    # user_not_found
+    log.warning(
+        "No account found for %s. Account creation is OAuth-only — the owner "
+        "must log in once via Google OAuth as %s, then re-run this script to "
+        "grant admin.",
+        result.email,
+        result.email,
+    )
+    return 1 if args.require_user else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bootstrap_admin.py
+++ b/tests/test_bootstrap_admin.py
@@ -1,0 +1,293 @@
+"""Tests for the idempotent admin-bootstrap script (us#159).
+
+The grant logic is exercised against a REAL in-memory SQLite database (always
+on, fast, deterministic) so the idempotency / no-op / no-crash guarantees are
+proven by real SQL, not by a mock. A second module-level class re-proves the
+same grant end-to-end against a throwaway Postgres container — opt-in and
+skip-guarded (``RUN_PG_CONTAINER_TESTS=1``) so the default CI run stays fast,
+mirroring ``test_oauth_account_linking_guard_pg.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import event, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from scripts.bootstrap_admin import (
+    DEFAULT_ADMIN_EMAIL,
+    BootstrapError,
+    GrantResult,
+    _resolve_database_url,
+    _resolve_email,
+    _to_async_url,
+    grant_admin,
+    main,
+    parse_args,
+)
+from src.app.models.role import Role, UserRole
+from src.app.models.user import Base, User
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite fixtures (always on) — mirrors the non-PG linking-guard test.
+# ---------------------------------------------------------------------------
+@pytest.fixture
+async def db_engine():  # type: ignore[no-untyped-def]
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def, type-arg]
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+
+async def _seed_admin_role(db: AsyncSession) -> Role:
+    role = Role(id=uuid.uuid4(), name="admin", description="Full platform administration access")
+    db.add(role)
+    await db.commit()
+    return role
+
+
+async def _seed_user(db: AsyncSession, email: str) -> User:
+    user = User(id=uuid.uuid4(), email=email, email_verified=True, is_active=True)
+    db.add(user)
+    await db.commit()
+    return user
+
+
+async def _count_admin_grants(db: AsyncSession, user_id: uuid.UUID, role_id: uuid.UUID) -> int:
+    result = await db.execute(
+        select(func.count())
+        .select_from(UserRole)
+        .where(UserRole.user_id == user_id, UserRole.role_id == role_id)
+    )
+    return int(result.scalar_one())
+
+
+# ---------------------------------------------------------------------------
+# grant_admin — the core idempotent logic
+# ---------------------------------------------------------------------------
+class TestGrantAdmin:
+    @pytest.mark.asyncio
+    async def test_grants_admin_to_existing_user(self, db_session: AsyncSession) -> None:
+        role = await _seed_admin_role(db_session)
+        user = await _seed_user(db_session, "parametrization@gmail.com")
+
+        result = await grant_admin(db_session, "parametrization@gmail.com")
+
+        assert result.status == "granted"
+        assert result.user_id == user.id
+        assert await _count_admin_grants(db_session, user.id, role.id) == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotent_running_twice_grants_once(self, db_session: AsyncSession) -> None:
+        role = await _seed_admin_role(db_session)
+        user = await _seed_user(db_session, "owner@example.com")
+
+        first = await grant_admin(db_session, "owner@example.com")
+        second = await grant_admin(db_session, "owner@example.com")
+
+        assert first.status == "granted"
+        assert second.status == "already_admin"
+        # Exactly one grant row despite two runs — the composite PK + the
+        # check-before-insert both protect against a duplicate.
+        assert await _count_admin_grants(db_session, user.id, role.id) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_already_admin(self, db_session: AsyncSession) -> None:
+        role = await _seed_admin_role(db_session)
+        user = await _seed_user(db_session, "owner@example.com")
+        # Pre-grant admin out-of-band, then assert the script reports no change.
+        db_session.add(UserRole(user_id=user.id, role_id=role.id, granted_by=None))
+        await db_session.commit()
+
+        result = await grant_admin(db_session, "owner@example.com")
+
+        assert result.status == "already_admin"
+        assert await _count_admin_grants(db_session, user.id, role.id) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_crash_when_user_absent(self, db_session: AsyncSession) -> None:
+        await _seed_admin_role(db_session)
+
+        result = await grant_admin(db_session, "nobody@example.com")
+
+        assert result == GrantResult(status="user_not_found", email="nobody@example.com")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_admin_role_missing(self, db_session: AsyncSession) -> None:
+        # User exists but the admin role was never seeded (unmigrated DB).
+        await _seed_user(db_session, "owner@example.com")
+
+        with pytest.raises(BootstrapError):
+            await grant_admin(db_session, "owner@example.com")
+
+
+# ---------------------------------------------------------------------------
+# URL normalisation
+# ---------------------------------------------------------------------------
+class TestToAsyncUrl:
+    def test_asyncpg_unchanged(self) -> None:
+        url = "postgresql+asyncpg://u:p@h:5432/db"
+        assert _to_async_url(url) == url
+
+    def test_bare_postgres_gets_asyncpg(self) -> None:
+        assert _to_async_url("postgresql://u:p@h:5432/db") == "postgresql+asyncpg://u:p@h:5432/db"
+
+    def test_psycopg2_swapped_to_asyncpg(self) -> None:
+        assert _to_async_url("postgresql+psycopg2://u:p@h/db") == "postgresql+asyncpg://u:p@h/db"
+
+    def test_sqlite_unchanged(self) -> None:
+        assert _to_async_url("sqlite+aiosqlite://") == "sqlite+aiosqlite://"
+
+
+# ---------------------------------------------------------------------------
+# CLI / resolution
+# ---------------------------------------------------------------------------
+class TestResolution:
+    def test_email_defaults_to_constant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BOOTSTRAP_ADMIN_EMAIL", raising=False)
+        assert _resolve_email(None) == DEFAULT_ADMIN_EMAIL
+        assert DEFAULT_ADMIN_EMAIL == "parametrization@gmail.com"
+
+    def test_email_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOOTSTRAP_ADMIN_EMAIL", "env@example.com")
+        assert _resolve_email(None) == "env@example.com"
+
+    def test_email_arg_beats_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOOTSTRAP_ADMIN_EMAIL", "env@example.com")
+        assert _resolve_email("arg@example.com") == "arg@example.com"
+
+    def test_database_url_arg_short_circuits(self) -> None:
+        # An explicit arg must not touch app settings at all.
+        assert _resolve_database_url("postgresql://x/y") == "postgresql://x/y"
+
+    def test_parse_args_defaults(self) -> None:
+        args = parse_args([])
+        assert args.email is None
+        assert args.database_url is None
+        assert args.require_user is False
+        assert args.verbose is False
+
+    def test_parse_args_require_user(self) -> None:
+        assert parse_args(["--require-user"]).require_user is True
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes — drive the whole script against in-memory SQLite.
+# ---------------------------------------------------------------------------
+# main() drives its OWN engine via run(), so these use a shared on-disk SQLite
+# file (not in-memory, which is per-connection) so the seed and the script see
+# the same database.
+class TestMainExitCodes:
+    @staticmethod
+    async def _create_schema_and_seed(url: str, *, seed_user: str | None) -> None:
+        engine = create_async_engine(url, echo=False)
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            session_factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with session_factory() as s:
+                await _seed_admin_role(s)
+                if seed_user is not None:
+                    await _seed_user(s, seed_user)
+        finally:
+            await engine.dispose()
+
+    def test_granted_exits_zero(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        url = f"sqlite+aiosqlite:///{tmp_path / 'bootstrap.db'}"
+        asyncio.run(self._create_schema_and_seed(url, seed_user="owner@example.com"))
+
+        assert main(["--email", "owner@example.com", "--database-url", url]) == 0
+
+    def test_user_absent_no_op_exits_zero(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        url = f"sqlite+aiosqlite:///{tmp_path / 'bootstrap.db'}"
+        asyncio.run(self._create_schema_and_seed(url, seed_user=None))
+
+        # Default: absent user is a clean no-op (deploy-safe).
+        assert main(["--email", "ghost@example.com", "--database-url", url]) == 0
+        # Strict mode: absent user is a hard error.
+        assert main(["--email", "ghost@example.com", "--database-url", url, "--require-user"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Real-Postgres proof (opt-in, skip-guarded). Mirrors the linking-guard PG test.
+# ---------------------------------------------------------------------------
+_PG_TESTS_ENABLED = os.getenv("RUN_PG_CONTAINER_TESTS") == "1"
+
+pg_only = pytest.mark.skipif(
+    not _PG_TESTS_ENABLED,
+    reason="Postgres container test is opt-in; set RUN_PG_CONTAINER_TESTS=1 to run.",
+)
+
+
+@pytest.fixture(scope="module")
+def pg_url() -> str:  # type: ignore[misc]
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:  # pragma: no cover - environment-dependent
+        pytest.skip("testcontainers not installed")
+
+    try:
+        postgres = PostgresContainer("postgres:16-alpine")
+        postgres.start()
+    except Exception as exc:  # pragma: no cover - environment-dependent
+        pytest.skip(f"Could not start Postgres container (Docker unavailable?): {exc}")
+
+    try:
+        sync_url = postgres.get_connection_url()
+        async_url = sync_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+            "postgresql://", "postgresql+asyncpg://"
+        )
+        yield async_url
+    finally:
+        postgres.stop()
+
+
+@pytest.fixture
+async def pg_session(pg_url: str) -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(pg_url, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            yield session
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pg_only
+class TestGrantAdminPostgres:
+    @pytest.mark.asyncio
+    async def test_grant_then_idempotent_on_real_postgres(self, pg_session: AsyncSession) -> None:
+        role = await _seed_admin_role(pg_session)
+        user = await _seed_user(pg_session, "parametrization@gmail.com")
+
+        first = await grant_admin(pg_session, "parametrization@gmail.com")
+        second = await grant_admin(pg_session, "parametrization@gmail.com")
+
+        assert first.status == "granted"
+        assert second.status == "already_admin"
+        assert await _count_admin_grants(pg_session, user.id, role.id) == 1


### PR DESCRIPTION
## What & why
Closes #159. The `admin` role is seeded by alembic `0001_initial_schema` but **no user holds it**, so every user-service admin endpoint — and the isnad-graph admin panels behind them (ig#805 user-mgmt, ig#806 data, ig#970 reset) — 401/403 for everyone. Chicken-and-egg: granting admin normally requires an admin to call the grant endpoint.

## Investigation (what I found)
- **No `parametrization` account is seeded anywhere** — `0001` seeds only the 4 roles. Account creation is **OAuth-only** (`find_or_create_oauth_user`); there is **no password-registration or password-login path** in the router/model.
- The `parametrization` account therefore materializes only when the owner first logs in via Google OAuth (as `parametrization@gmail.com`).
- `user_roles(user_id, role_id, granted_at, granted_by)` is the join table; `granted_by` is nullable (`ON DELETE SET NULL`).

## Mechanism chosen (and why)
An **idempotent operator grant-if-exists script** — `scripts/bootstrap_admin.py` — that **elevates the existing account**, never creates one and never sets a credential.

Rejected alternatives:
- A **password-bootstrap account** would be unusable (no password login exists).
- A **pure data migration** would no-op on a fresh DB and never re-run after the owner's first login, so it can't actually grant.

Supported flow:
1. Owner logs in once via Google OAuth as the bootstrap email (default `parametrization@gmail.com`). That creates the user row.
2. Run `make bootstrap-admin` (or `python scripts/bootstrap_admin.py`) — locally or as a post-deploy step. It grants admin.

## Safety / idempotency
- Running twice ⇒ exactly one grant (second run reports `already_admin`).
- **No-op exit 0** when the user doesn't exist yet, so it can run unattended in a deploy *before* the owner ever logs in without crashing the deploy. `--require-user` makes an absent user a hard error (exit 1).
- `BootstrapError` (exit 1) only on genuine misconfiguration (admin role missing ⇒ unmigrated DB).
- Email override: `--email` / `BOOTSTRAP_ADMIN_EMAIL`. DB URL: `--database-url` / app settings.

## Tests
`tests/test_bootstrap_admin.py` — idempotency (twice ⇒ one grant), no-op-when-already-admin, no-crash-when-user-absent, unmigrated-DB error, URL normalisation, CLI resolution, and `main()` exit codes. Run against **real in-memory SQLite** (always on) + an **opt-in real-Postgres container** (`RUN_PG_CONTAINER_TESTS=1`, skip-guarded — mirrors `test_oauth_account_linking_guard_pg.py`).

Gates: `ruff check .` ✓ · `ruff format --check .` ✓ · full `pytest` 331 passed / 4 skipped ✓ · `mypy` clean on the new script. (Pre-existing `scripts/migrate_users.py` mypy errors are untouched and out of the gated `mypy src/` scope.)

## Owner decision surfaced
**Bootstrap identity = `parametrization@gmail.com`** (matches the owner email; configurable). If a different identity is intended for the first admin, set `BOOTSTRAP_ADMIN_EMAIL` — flagging in case that's an owner call.

**Recommended follow-up (separate, cross-repo):** wire `make bootstrap-admin` into the `noorinalabs-deploy` post-migrate step so the grant is reasserted on every deploy (the script is already safe to run unattended). Not done here to keep this PR repo-scoped.

## Reviewers
- **Anya Kowalczyk** (tech lead) — primary
- **Nadia Boukhari** (manager) — secondary
