### PR TITLE
infra(docker): bump base image to clear CVE-2026-45447 (#157)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@
 # dependency compatibility first (cf. PR #41 "3.14 breaks deps"), land the base
 # switch in its own PR, and drop any then-redundant .trivyignore entries.
 #
-# Last pin: 2026-05-31 (digest resolved from Docker Hub at PR-open time).
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS base
+# Last pin: 2026-06-12 (digest resolved from Docker Hub at PR-open time) —
+# re-pinned per the "Trivy gate surfaces an OS-level CVE" cadence: the prior pin
+# carried openssl/libssl3t64 3.5.6-1~deb13u1, vulnerable to CVE-2026-45447 (HIGH),
+# which began tripping ghcr-publish's Trivy gate on every PR once disclosed
+# (us#157). This digest ships 3.5.6-1~deb13u2, the Debian backport that fixes it.
+FROM python:3.12-slim@sha256:a39549e211a16149edf74e5fdc9ef03a6767e46cd987c5048b6659b6c9904c94 AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \


### PR DESCRIPTION
Closes #157

## What

Re-pin the `python:3.12-slim` base image in `Dockerfile` from
`@sha256:090ba77e…` to the current multi-arch index digest
`@sha256:a39549e2…`.

## Why

The old digest baked `openssl` / `libssl3t64` at **`3.5.6-1~deb13u1`**,
which is vulnerable to **CVE-2026-45447** (HIGH — heap use-after-free in
OpenSSL `PKCS7_verify()`, fixed in `3.5.6-1~deb13u2`). Once that advisory
was disclosed it began tripping `ghcr-publish`'s Trivy gate on every PR,
independent of the PR's content (first observed on us#156). The new
digest ships the Debian `~deb13u2` backport that fixes it.

This follows the `Dockerfile`'s own documented re-pin cadence
("…OR whenever CI's Trivy gate surfaces OS-level CVE failures the current
pin can't satisfy") rather than adding a `.trivyignore` entry — the fix
exists upstream, so suppression is the wrong surface per the `.trivyignore`
policy header. Multi-arch index digest, so the amd64+arm64 push build is
unaffected. The bump is a pure OS security backport (same upstream
OpenSSL 3.5.6) — no library major-version shift, so deps are unaffected.

## Verification (local docker + Trivy 0.58.0)

| Target | openssl/libssl3t64 | CVE-2026-45447 (Trivy) |
|---|---|---|
| OLD bare base `@090ba77` | `3.5.6-1~deb13u1` | **present (HIGH, fixed-status → gates)** |
| NEW bare base `@a39549e` | `3.5.6-1~deb13u2` | **absent** |
| NEW full built image | `libssl-dev`/`libssl3t64`/`openssl` all `~deb13u2` | **absent** |

- `docker build` of the full image succeeds; `uv sync --frozen --no-dev`
  installs all runtime deps; `import src.app.main` OK.
- Trivy on the new built image under the exact CI flags
  (`--ignore-unfixed --severity CRITICAL,HIGH --scanners vuln`):
  **`Total: 0 (HIGH: 0, CRITICAL: 0)`**.

**Honest caveat on the build cache:** a *fresh* local rebuild of even the
*old* pin currently also resolves `~deb13u2`, because the runtime stage's
`apt-get update && apt-get install … libpq-dev` pulls `libssl-dev`
(→ `libssl3t64`) from the live Debian mirror, which now carries the fix.
The clean reproduction of CI's RED is therefore the **bare-base** scan
above. The durable fix is the digest bump: it bakes `~deb13u2` into the
base layer itself **and** busts the cached `apt` layer so CI's build
re-resolves the patched package rather than reusing a stale deb13u1 layer.

## Trivy expectation

`build-and-push` (ghcr-publish, Trivy image scan) should go **green** on
this PR — CVE-2026-45447 is the only base-image HIGH the issue cites, and
it is cleared. No `.trivyignore` change needed (it stays empty/fully
active).

## Reviewers
@Anya Kowalczyk (tech lead, primary) · @Mateo Salazar (secondary)

## Test Plan
- [ ] CI `build-and-push` Trivy scan passes (no HIGH base-image CVEs).
- [ ] Image builds + service boots in staging (runtime image unaffected functionally).
