### PR TITLE
feat(users): admin user-stats endpoint for dashboard counts (ig#1051)

### DIFF
--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -247,6 +247,24 @@
         "title": "RoleAssignment",
         "type": "object"
       },
+      "RoleCount": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "count"
+        ],
+        "title": "RoleCount",
+        "type": "object"
+      },
       "RoleRead": {
         "properties": {
           "created_at": {
@@ -810,6 +828,48 @@
           "created_at"
         ],
         "title": "UserRead",
+        "type": "object"
+      },
+      "UserStats": {
+        "description": "Aggregate user counts for the admin dashboard.\n\n``deactivated_users`` counts soft-deleted accounts (``is_active = false``);\nthe service has no separate \"suspended\" state. ``active_sessions`` is the\nnumber of non-revoked, unexpired session rows across all users.",
+        "properties": {
+          "active_sessions": {
+            "title": "Active Sessions",
+            "type": "integer"
+          },
+          "active_users": {
+            "title": "Active Users",
+            "type": "integer"
+          },
+          "by_role": {
+            "items": {
+              "$ref": "#/components/schemas/RoleCount"
+            },
+            "title": "By Role",
+            "type": "array"
+          },
+          "deactivated_users": {
+            "title": "Deactivated Users",
+            "type": "integer"
+          },
+          "new_registrations_7d": {
+            "title": "New Registrations 7D",
+            "type": "integer"
+          },
+          "total_users": {
+            "title": "Total Users",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_users",
+          "active_users",
+          "deactivated_users",
+          "new_registrations_7d",
+          "active_sessions",
+          "by_role"
+        ],
+        "title": "UserStats",
         "type": "object"
       },
       "UserUpdate": {
@@ -1884,6 +1944,49 @@
           }
         },
         "summary": "Update Current User Profile",
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/stats": {
+      "get": {
+        "description": "Return aggregate user counts for the admin dashboard (admin only).",
+        "operationId": "get_user_stats_api_v1_users_stats_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": true,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStats"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get User Stats",
         "tags": [
           "users"
         ]

--- a/src/app/routers/users.py
+++ b/src/app/routers/users.py
@@ -8,6 +8,7 @@ from src.app.schemas.user import (
     RoleRead,
     UserListResponse,
     UserRead,
+    UserStats,
     UserUpdate,
 )
 from src.app.services import rbac
@@ -48,6 +49,17 @@ async def update_current_user_profile(
     updated = await user_svc.update_profile(db, current_user, data)
     await db.commit()
     return _user_to_read(updated)
+
+
+# Registered before the `/{user_id}` route so "stats" is matched as a literal
+# path segment rather than parsed as a (then-invalid) user UUID.
+@router.get("/stats", response_model=UserStats)
+async def get_user_stats(
+    _admin: AdminUserDep,
+    db: DbDep,
+) -> UserStats:
+    """Return aggregate user counts for the admin dashboard (admin only)."""
+    return await user_svc.get_user_stats(db)
 
 
 @router.get("/{user_id}", response_model=UserRead)

--- a/src/app/schemas/user.py
+++ b/src/app/schemas/user.py
@@ -40,6 +40,31 @@ class UserListResponse(BaseModel):
     model_config = {"frozen": True}
 
 
+class RoleCount(BaseModel):
+    role: str
+    count: int
+
+    model_config = {"frozen": True}
+
+
+class UserStats(BaseModel):
+    """Aggregate user counts for the admin dashboard.
+
+    ``deactivated_users`` counts soft-deleted accounts (``is_active = false``);
+    the service has no separate "suspended" state. ``active_sessions`` is the
+    number of non-revoked, unexpired session rows across all users.
+    """
+
+    total_users: int
+    active_users: int
+    deactivated_users: int
+    new_registrations_7d: int
+    active_sessions: int
+    by_role: list[RoleCount]
+
+    model_config = {"frozen": True}
+
+
 class RoleRead(BaseModel):
     id: uuid.UUID
     name: str

--- a/src/app/services/user.py
+++ b/src/app/services/user.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 
 import uuid
 from base64 import b64decode, b64encode
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from src.app.models.oauth_account import OAuthAccount
-from src.app.models.role import UserRole
+from src.app.models.role import Role, UserRole
+from src.app.models.session import Session
 from src.app.models.user import User
-from src.app.schemas.user import UserUpdate
+from src.app.schemas.user import RoleCount, UserStats, UserUpdate
 from src.app.utils.crypto import hash_password, verify_password
 
 # Pre-computed bcrypt hash used purely to equalize login timing when no user (or
@@ -81,6 +82,52 @@ async def list_users(
         next_cursor = b64encode(raw.encode()).decode()
 
     return users, next_cursor
+
+
+async def get_user_stats(db: AsyncSession) -> UserStats:
+    """Aggregate user counts for the admin dashboard.
+
+    All counts are computed with SQL aggregates (no row materialization), so
+    this stays cheap as the user table grows. ``deactivated_users`` is derived
+    as ``total - active`` to keep the two figures internally consistent.
+    """
+    total_users = (await db.execute(select(func.count()).select_from(User))).scalar_one()
+    active_users = (
+        await db.execute(select(func.count()).select_from(User).where(User.is_active.is_(True)))
+    ).scalar_one()
+
+    week_ago = datetime.now(UTC) - timedelta(days=7)
+    new_registrations_7d = (
+        await db.execute(select(func.count()).select_from(User).where(User.created_at >= week_ago))
+    ).scalar_one()
+
+    now = datetime.now(UTC)
+    active_sessions = (
+        await db.execute(
+            select(func.count())
+            .select_from(Session)
+            .where(Session.revoked_at.is_(None), Session.expires_at > now)
+        )
+    ).scalar_one()
+
+    role_rows = (
+        await db.execute(
+            select(Role.name, func.count(UserRole.user_id))
+            .join(UserRole, UserRole.role_id == Role.id)
+            .group_by(Role.name)
+            .order_by(Role.name)
+        )
+    ).all()
+    by_role = [RoleCount(role=name, count=count) for name, count in role_rows]
+
+    return UserStats(
+        total_users=total_users,
+        active_users=active_users,
+        deactivated_users=total_users - active_users,
+        new_registrations_7d=new_registrations_7d,
+        active_sessions=active_sessions,
+        by_role=by_role,
+    )
 
 
 async def soft_delete(db: AsyncSession, user_id: uuid.UUID) -> User | None:

--- a/tests/test_users_crud.py
+++ b/tests/test_users_crud.py
@@ -16,6 +16,7 @@ from src.app.config import Settings
 from src.app.database import get_db_session
 from src.app.main import create_app
 from src.app.models.role import Role, UserRole
+from src.app.models.session import Session
 from src.app.models.user import Base, User
 
 # Generate a test RSA key pair (once per module)
@@ -324,4 +325,90 @@ class TestRoleEndpoints:
             headers=_auth_header(regular_user),
             json={"role_id": str(seed_roles["researcher"].id)},
         )
+        assert resp.status_code == 403
+
+
+class TestUserStats:
+    @pytest.mark.asyncio
+    async def test_admin_gets_aggregate_counts(
+        self,
+        client: AsyncClient,
+        admin_user: User,
+        regular_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # A soft-deleted account (counts toward total + deactivated, not active).
+        inactive = User(email="gone@test.com", email_verified=True, is_active=False)
+        db_session.add(inactive)
+        # An account older than the 7-day registration window.
+        old = User(
+            email="old@test.com",
+            email_verified=True,
+            is_active=True,
+            created_at=datetime.now(UTC) - timedelta(days=30),
+        )
+        db_session.add(old)
+        await db_session.flush()
+
+        # One live session and one revoked session for the same user — only the
+        # live one should count toward active_sessions.
+        db_session.add(
+            Session(
+                user_id=admin_user.id,
+                token_hash="live-token",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+            )
+        )
+        db_session.add(
+            Session(
+                user_id=admin_user.id,
+                token_hash="revoked-token",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+                revoked_at=datetime.now(UTC),
+            )
+        )
+        # An expired session — also excluded.
+        db_session.add(
+            Session(
+                user_id=regular_user.id,
+                token_hash="expired-token",
+                expires_at=datetime.now(UTC) - timedelta(hours=1),
+            )
+        )
+        await db_session.commit()
+
+        resp = await client.get("/api/v1/users/stats", headers=_auth_header(admin_user))
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # admin_user + regular_user + inactive + old
+        assert data["total_users"] == 4
+        assert data["active_users"] == 3
+        assert data["deactivated_users"] == 1
+        # admin + regular + inactive registered "now"; `old` is 30 days back.
+        assert data["new_registrations_7d"] == 3
+        assert data["active_sessions"] == 1
+
+        by_role = {r["role"]: r["count"] for r in data["by_role"]}
+        assert by_role["admin"] == 1
+        assert by_role["reader"] == 1
+
+    @pytest.mark.asyncio
+    async def test_non_admin_forbidden(self, client: AsyncClient, regular_user: User) -> None:
+        resp = await client.get("/api/v1/users/stats", headers=_auth_header(regular_user))
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_rejected(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/users/stats")
+        assert resp.status_code in (401, 422)
+
+    @pytest.mark.asyncio
+    async def test_stats_path_not_parsed_as_user_id(
+        self, client: AsyncClient, regular_user: User
+    ) -> None:
+        # Guards the route ordering: GET /users/stats must hit the stats handler
+        # (403 for a non-admin), NOT the /{user_id} handler (which would 422 on
+        # the non-UUID "stats" path segment).
+        resp = await client.get("/api/v1/users/stats", headers=_auth_header(regular_user))
         assert resp.status_code == 403


### PR DESCRIPTION
## What

Adds `GET /api/v1/users/stats` (admin-gated) returning aggregate user counts for the isnad-graph admin dashboard. This is the **cross-repo companion** to [`noorinalabs-isnad-graph#1051`](https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/1051) — the isnad-graph admin dashboard currently **stubs** user counts ("a future integration with user-service will restore user counts"). This endpoint is that integration.

## Response (`UserStats`)

| field | meaning |
|---|---|
| `total_users` | all rows in `users` |
| `active_users` | `is_active = true` |
| `deactivated_users` | soft-deleted (`is_active = false`); derived as `total - active` |
| `new_registrations_7d` | `created_at` within the last 7 days |
| `active_sessions` | non-revoked, unexpired `sessions` rows (all users) |
| `by_role` | `[{role, count}]` from `roles ⋈ user_roles` |

All counts use SQL aggregates (no row materialization), so the endpoint stays cheap as the table grows.

## Notes

- Route registered **before** `/{user_id}` so `stats` is matched as a literal segment, not parsed as a (then-invalid) user UUID — covered by a regression test.
- There is no "suspended" state in this service; the honest label is **deactivated**. The isnad-graph PR labels the dashboard card accordingly.
- Regenerated `docs/openapi-snapshot.json` via `make openapi-snapshot` so the isnad-graph frontend consumes the contract through its surgical-addition typegen flow.

## Tests

`tests/test_users_crud.py::TestUserStats` — aggregate correctness (active/deactivated/7d/sessions/by_role with revoked + expired sessions excluded), admin-gating (403 non-admin), unauthenticated rejection, and the route-ordering guard.

Gates green locally: `ruff check`, `ruff format --check`, `mypy` (strict), `pytest`, OpenAPI snapshot drift.

Refs ig#1051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)