### PR TITLE
feat(profile): JSONB preferences column + /users/me/profile endpoints (#165)

### DIFF
--- a/alembic/versions/0042_add_users_preferences.py
+++ b/alembic/versions/0042_add_users_preferences.py
@@ -12,8 +12,9 @@ Create Date: 2026-06-14
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
+
+from alembic import op
 
 revision: str = "0042"
 down_revision: str = "0041"

--- a/alembic/versions/0042_add_users_preferences.py
+++ b/alembic/versions/0042_add_users_preferences.py
@@ -1,0 +1,37 @@
+"""Add JSONB preferences column to users.
+
+US #165 — stores arbitrary per-user UI/UX preferences (theme, language, …).
+NOT NULL with a server default of ``'{}'`` so existing rows backfill to an
+empty object and the column is never NULL for downstream readers.
+
+Revision ID: 0042
+Revises: 0041
+Create Date: 2026-06-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0042"
+down_revision: str = "0041"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "preferences",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "preferences")

--- a/alembic/versions/MIGRATION_RANGES.md
+++ b/alembic/versions/MIGRATION_RANGES.md
@@ -11,6 +11,7 @@ each Phase 3 issue has a reserved range:
 | 0030–0039 | US #10 | 2FA / TOTP            |
 | 0040      | US #63 | Merge multi-heads     |
 | 0041      | US #54 | subscriptions.user_id index (tech-debt) |
+| 0042      | US #165 | users.preferences JSONB column |
 
 Name your migration files with the appropriate prefix, e.g.:
 `0010_add_verification_tokens.py` for US #8.

--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -140,6 +140,76 @@
         "title": "OAuthLoginResponse",
         "type": "object"
       },
+      "ProfilePreferences": {
+        "additionalProperties": true,
+        "description": "A user's preferences. Known keys are validated; extra keys pass through.\n\n``extra=\"allow\"`` keeps unrecognized keys, so the model both validates the\nwell-known prefs and serves as a transparent container for client-defined\nones.",
+        "properties": {
+          "language": {
+            "anyOf": [
+              {
+                "maxLength": 35,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "theme": {
+            "anyOf": [
+              {
+                "enum": [
+                  "light",
+                  "dark",
+                  "system"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Theme"
+          }
+        },
+        "title": "ProfilePreferences",
+        "type": "object"
+      },
+      "ProfileRead": {
+        "description": "The authenticated user's profile preferences.",
+        "properties": {
+          "preferences": {
+            "additionalProperties": true,
+            "title": "Preferences",
+            "type": "object"
+          },
+          "user_id": {
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "preferences"
+        ],
+        "title": "ProfileRead",
+        "type": "object"
+      },
+      "ProfileUpdate": {
+        "description": "Replace the authenticated user's preferences (PUT semantics).\n\nThe submitted ``preferences`` object replaces the stored one wholesale \u2014 a\nsettings page reads the full object and writes it back, so partial-merge\nsurprises are avoided.",
+        "properties": {
+          "preferences": {
+            "$ref": "#/components/schemas/ProfilePreferences"
+          }
+        },
+        "required": [
+          "preferences"
+        ],
+        "title": "ProfileUpdate",
+        "type": "object"
+      },
       "ProvidersResponse": {
         "description": "List of authentication methods the service supports + their enabled state.",
         "properties": {
@@ -1944,6 +2014,100 @@
           }
         },
         "summary": "Update Current User Profile",
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/me/profile": {
+      "get": {
+        "description": "Return the authenticated user's preferences blob (own profile only).",
+        "operationId": "get_current_user_preferences_api_v1_users_me_profile_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": true,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Current User Preferences",
+        "tags": [
+          "users"
+        ]
+      },
+      "put": {
+        "description": "Replace the authenticated user's preferences wholesale (own profile only).",
+        "operationId": "replace_current_user_preferences_api_v1_users_me_profile_put",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": true,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Replace Current User Preferences",
         "tags": [
           "users"
         ]

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy import JSON, Boolean, DateTime, String, func, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
@@ -25,6 +26,15 @@ class User(Base):
     password_hash: Mapped[str | None] = mapped_column(String(255))
     avatar_url: Mapped[str | None] = mapped_column(String(512))
     locale: Mapped[str | None] = mapped_column(String(10))
+    # Free-form user preferences (theme, language, …) — JSONB on Postgres, plain
+    # JSON on SQLite (tests). `default=dict` / `server_default='{}'` guarantee the
+    # column is never NULL, so consumers can read `preferences["key"]` defensively.
+    preferences: Mapped[dict[str, Any]] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'"),
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/app/routers/users.py
+++ b/src/app/routers/users.py
@@ -3,6 +3,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Query, status
 
 from src.app.dependencies import AdminUserDep, CurrentUserDep, DbDep
+from src.app.schemas.profile import ProfileRead, ProfileUpdate
 from src.app.schemas.user import (
     RoleAssignment,
     RoleRead,
@@ -49,6 +50,31 @@ async def update_current_user_profile(
     updated = await user_svc.update_profile(db, current_user, data)
     await db.commit()
     return _user_to_read(updated)
+
+
+def _profile_to_read(u: object) -> ProfileRead:
+    from src.app.models.user import User
+
+    assert isinstance(u, User)
+    return ProfileRead(user_id=u.id, preferences=u.preferences or {})
+
+
+@router.get("/me/profile", response_model=ProfileRead)
+async def get_current_user_preferences(current_user: CurrentUserDep) -> ProfileRead:
+    """Return the authenticated user's preferences blob (own profile only)."""
+    return _profile_to_read(current_user)
+
+
+@router.put("/me/profile", response_model=ProfileRead)
+async def replace_current_user_preferences(
+    data: ProfileUpdate,
+    current_user: CurrentUserDep,
+    db: DbDep,
+) -> ProfileRead:
+    """Replace the authenticated user's preferences wholesale (own profile only)."""
+    updated = await user_svc.replace_preferences(db, current_user, data.preferences.to_storage())
+    await db.commit()
+    return _profile_to_read(updated)
 
 
 # Registered before the `/{user_id}` route so "stats" is matched as a literal

--- a/src/app/schemas/profile.py
+++ b/src/app/schemas/profile.py
@@ -1,0 +1,66 @@
+"""Profile / preferences schemas — US #165.
+
+The user-service stores arbitrary UI/UX preferences in a JSONB column. A small
+set of well-known keys (``theme``, ``language``) is type-checked; any other key
+is accepted and round-tripped untouched so new client preferences need no schema
+or migration change. A byte cap bounds JSONB growth (a user-writable column is
+otherwise an unbounded-storage surface).
+"""
+
+import json
+import uuid
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Upper bound on the JSON-serialized preferences blob. Generous for real UI
+# settings while denying a user from stuffing the column with arbitrary payload.
+MAX_PREFERENCES_BYTES = 8192
+
+
+class ProfilePreferences(BaseModel):
+    """A user's preferences. Known keys are validated; extra keys pass through.
+
+    ``extra="allow"`` keeps unrecognized keys, so the model both validates the
+    well-known prefs and serves as a transparent container for client-defined
+    ones.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    theme: Literal["light", "dark", "system"] | None = None
+    language: str | None = Field(default=None, max_length=35)
+
+    @model_validator(mode="after")
+    def _enforce_size_limit(self) -> "ProfilePreferences":
+        encoded = json.dumps(self.model_dump(exclude_none=True)).encode("utf-8")
+        if len(encoded) > MAX_PREFERENCES_BYTES:
+            msg = f"preferences exceed the {MAX_PREFERENCES_BYTES}-byte limit"
+            raise ValueError(msg)
+        return self
+
+    def to_storage(self) -> dict[str, Any]:
+        """Plain dict to persist — drops keys whose value is ``None``."""
+        return self.model_dump(exclude_none=True)
+
+
+class ProfileRead(BaseModel):
+    """The authenticated user's profile preferences."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_id: uuid.UUID
+    preferences: dict[str, Any]
+
+
+class ProfileUpdate(BaseModel):
+    """Replace the authenticated user's preferences (PUT semantics).
+
+    The submitted ``preferences`` object replaces the stored one wholesale — a
+    settings page reads the full object and writes it back, so partial-merge
+    surprises are avoided.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    preferences: ProfilePreferences

--- a/src/app/services/user.py
+++ b/src/app/services/user.py
@@ -45,6 +45,19 @@ async def update_profile(db: AsyncSession, user: User, data: UserUpdate) -> User
     return user
 
 
+async def replace_preferences(db: AsyncSession, user: User, preferences: dict[str, object]) -> User:
+    """Replace the user's preferences blob (PUT semantics).
+
+    Assigning a brand-new dict makes SQLAlchemy mark the JSON column dirty (it
+    tracks attribute reassignment, not in-place mutation), so the update is
+    persisted without needing a mutable-dict wrapper.
+    """
+    user.preferences = dict(preferences)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
 async def list_users(
     db: AsyncSession,
     cursor: str | None = None,

--- a/tests/test_profile_endpoints.py
+++ b/tests/test_profile_endpoints.py
@@ -1,0 +1,237 @@
+"""Tests for the profile preferences API — US #165.
+
+Covers GET/PUT ``/api/v1/users/me/profile``: default empty prefs, round-trip of
+known + arbitrary keys, PUT replace semantics, validation (bad theme, oversized
+blob), auth gating, and RBAC isolation (a user only ever reads/writes their own
+preferences).
+"""
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.app.config import Settings, get_settings
+from src.app.database import get_db_session
+from src.app.main import create_app
+from src.app.models.user import Base, User
+
+_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+TEST_PRIVATE_PEM = _test_private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode()
+TEST_PUBLIC_PEM = (
+    _test_private_key.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+
+def _make_token(user_id: uuid.UUID) -> str:
+    payload = {"sub": str(user_id), "exp": datetime.now(UTC) + timedelta(hours=1)}
+    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
+
+
+def _auth_header(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_make_token(user.id)}"}
+
+
+@pytest.fixture
+async def db_engine():  # type: ignore[no-untyped-def]
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def]
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+
+async def _make_user(db_session: AsyncSession, email: str) -> User:
+    user = User(email=email, display_name=email, email_verified=True, is_active=True)
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+@pytest.fixture
+async def user_a(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, "a@test.com")
+
+
+@pytest.fixture
+async def user_b(db_session: AsyncSession) -> User:
+    return await _make_user(db_session, "b@test.com")
+
+
+@pytest.fixture
+async def client(
+    db_engine,  # type: ignore[no-untyped-def]
+    db_session: AsyncSession,
+) -> AsyncGenerator[AsyncClient, None]:
+    app = create_app()
+
+    def _override_settings() -> Settings:
+        return Settings(JWT_PUBLIC_KEY=TEST_PUBLIC_PEM, DATABASE_URL="sqlite+aiosqlite://")
+
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_settings] = _override_settings
+    app.dependency_overrides[get_db_session] = _override_db
+
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestGetProfile:
+    @pytest.mark.asyncio
+    async def test_defaults_to_empty_preferences(self, client: AsyncClient, user_a: User) -> None:
+        resp = await client.get("/api/v1/users/me/profile", headers=_auth_header(user_a))
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["user_id"] == str(user_a.id)
+        assert body["preferences"] == {}
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_rejected(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/v1/users/me/profile")
+        assert resp.status_code in (401, 422)
+
+
+class TestPutProfile:
+    @pytest.mark.asyncio
+    async def test_set_and_read_back_known_keys(self, client: AsyncClient, user_a: User) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "dark", "language": "ar"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preferences"] == {"theme": "dark", "language": "ar"}
+
+        # Persisted across requests.
+        resp = await client.get("/api/v1/users/me/profile", headers=_auth_header(user_a))
+        assert resp.json()["preferences"] == {"theme": "dark", "language": "ar"}
+
+    @pytest.mark.asyncio
+    async def test_arbitrary_keys_pass_through(self, client: AsyncClient, user_a: User) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "light", "density": "compact", "beta": True}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preferences"] == {
+            "theme": "light",
+            "density": "compact",
+            "beta": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_put_replaces_wholesale(self, client: AsyncClient, user_a: User) -> None:
+        await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "dark", "language": "en"}},
+        )
+        # A subsequent PUT with only `theme` drops the previously stored `language`.
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "system"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preferences"] == {"theme": "system"}
+
+    @pytest.mark.asyncio
+    async def test_none_valued_known_key_is_dropped(
+        self, client: AsyncClient, user_a: User
+    ) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": None, "language": "fr"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["preferences"] == {"language": "fr"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_theme_rejected(self, client: AsyncClient, user_a: User) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "neon"}},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_oversized_preferences_rejected(self, client: AsyncClient, user_a: User) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"blob": "x" * 9000}},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_rejected(self, client: AsyncClient) -> None:
+        resp = await client.put(
+            "/api/v1/users/me/profile",
+            json={"preferences": {"theme": "dark"}},
+        )
+        assert resp.status_code in (401, 422)
+
+
+class TestProfileRbacIsolation:
+    @pytest.mark.asyncio
+    async def test_users_have_independent_preferences(
+        self, client: AsyncClient, user_a: User, user_b: User
+    ) -> None:
+        # user_a writes their preferences.
+        await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_a),
+            json={"preferences": {"theme": "dark"}},
+        )
+        # user_b's profile is unaffected — each token only ever resolves to its
+        # own user (no cross-user read/write surface).
+        resp_b = await client.get("/api/v1/users/me/profile", headers=_auth_header(user_b))
+        assert resp_b.json()["preferences"] == {}
+
+        # user_b writes their own — user_a still sees theirs.
+        await client.put(
+            "/api/v1/users/me/profile",
+            headers=_auth_header(user_b),
+            json={"preferences": {"theme": "light"}},
+        )
+        resp_a = await client.get("/api/v1/users/me/profile", headers=_auth_header(user_a))
+        assert resp_a.json()["preferences"] == {"theme": "dark"}


### PR DESCRIPTION
## Summary

Implements **#165** — JSONB user preferences + profile endpoints.

- **New `users.preferences` JSONB column** (Alembic `0042`, `NOT NULL DEFAULT '{}'`). Holds arbitrary per-user UI/UX prefs; `theme` + `language` are the well-known keys.
- **`GET /api/v1/users/me/profile`** — returns `{ "user_id", "preferences" }` for the authenticated user.
- **`PUT /api/v1/users/me/profile`** — replaces the caller's preferences wholesale (PUT semantics). Known keys validated (`theme` ∈ {light,dark,system}; `language` ≤ 35 chars); unknown keys pass through; total blob capped at 8 KB to bound JSONB growth.
- **RBAC**: both routes resolve only the bearer token's own user — there is no path to read/write another user's profile.

### `/sessions` note
The issue's `/sessions` deliverable is **already satisfied** by the existing `GET /api/v1/sessions` (US #7), which lists the caller's active (non-revoked, non-expired) sessions filtered by `user_id`. I did **not** add a duplicate endpoint; isolation is already covered by `test_session_service.py`.

### Consumer-facing shape (for ig#1044 / ig#1013, P5W4 Batch 2)
```
GET  /api/v1/users/me/profile  -> 200 { "user_id": "<uuid>", "preferences": { "theme": "dark", "language": "ar", ... } }
PUT  /api/v1/users/me/profile     body: { "preferences": { "theme": "dark", "language": "ar" } }  -> 200 same shape
```
`OpenAPI` snapshot (`docs/openapi-snapshot.json`) regenerated so the drift gate passes; `ProfileRead`/`ProfileUpdate`/`ProfilePreferences` schemas are documented there.

## Implementation notes
- **Dialect portability**: the column is `JSON().with_variant(JSONB(), "postgresql")` so Postgres gets real JSONB while the SQLite-backed test suite still builds the schema. The migration uses `postgresql.JSONB` directly (Postgres-only; no test/CI step applies migrations on SQLite).
- PUT assigns a brand-new dict, so SQLAlchemy marks the JSON column dirty without a mutable-dict wrapper.

## Test Plan
- `ruff check` / `ruff format --check` — clean
- `mypy src/` (strict) — clean
- `pytest` — **359 passed, 4 skipped** (8 new profile tests: defaults, known + arbitrary-key round-trip, replace semantics, `None`-key drop, invalid-theme 422, oversized-blob 422, auth gating, RBAC isolation)
- `make openapi-snapshot` regenerated and committed (drift gate green)

## Reviewers
@Anya-Kowalczyk (tech lead) and @Idris-Yusuf (security). Focus areas:
- **Idris**: the 8 KB preferences cap as the unbounded-storage guard on a user-writable JSONB column — is the bound + enforcement point (Pydantic `model_validator`) right? Any other abuse surface on free-form JSON?
- **Anya**: PUT-replace vs PATCH-merge semantics choice; the dialect-variant column type; route ordering (`/me/profile` registered before `/{user_id}`).

Closes #165
