### PR TITLE
feat(auth): parent-domain SSO cookie + GET /auth/forward-auth (us#171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,18 @@ AUTH_OAUTH_STATE_TTL_SECONDS=600
 # Secure flag on the refresh_token cookie. Must be true in production (HTTPS);
 # set to false in local HTTP development.
 AUTH_OAUTH_REFRESH_COOKIE_SECURE=true
+
+# SSO session cookie — parent-domain carry for Caddy forward_auth (us#171 /
+# deploy#458). Minted by POST /auth/sso-cookie from a valid app bearer and
+# validated by GET /auth/forward-auth. Parent-domain scoping lets a top-level
+# browser nav to a sibling subdomain (isnad.{base}/grafana) carry the credential.
+AUTH_SSO_COOKIE_NAME=nl_sso
+# Parent domain shared by every subdomain that must receive the cookie. In prod
+# this is the registrable apex (noorinalabs.com); set a staging base in staging.
+AUTH_SSO_COOKIE_DOMAIN=noorinalabs.com
+# Short TTL in seconds (bounds post-revocation staleness — forward-auth trusts the
+# signed claim rather than a live DB read).
+AUTH_SSO_COOKIE_TTL_SECONDS=300
+# Secure flag on the SSO cookie. Must be true in production (HTTPS); set to false
+# only for local HTTP development.
+AUTH_SSO_COOKIE_SECURE=true

--- a/docs/openapi-snapshot.json
+++ b/docs/openapi-snapshot.json
@@ -25,6 +25,18 @@
         "title": "AuthProviderInfo",
         "type": "object"
       },
+      "ForwardAuthResponse": {
+        "description": "Body for a successful `GET /auth/forward-auth`.\n\nThe load-bearing output is the `X-Webauth-User` / `X-Webauth-Role` response\nheaders that Caddy copies upstream to Grafana; the body is a minimal ack.",
+        "properties": {
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "ForwardAuthResponse",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -478,6 +490,30 @@
           "expires_at"
         ],
         "title": "SessionResponse",
+        "type": "object"
+      },
+      "SsoCookieResponse": {
+        "description": "Acknowledgement for `POST /auth/sso-cookie`.\n\nThe credential itself rides in the `Set-Cookie` header \u2014 the body only echoes\nthe cookie name and lifetime so the frontend can schedule a re-mint before the\nshort TTL lapses (us#171).",
+        "properties": {
+          "cookie_name": {
+            "title": "Cookie Name",
+            "type": "string"
+          },
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cookie_name",
+          "expires_in"
+        ],
+        "title": "SsoCookieResponse",
         "type": "object"
       },
       "SubscriptionCreate": {
@@ -2560,6 +2596,28 @@
         ]
       }
     },
+    "/auth/forward-auth": {
+      "get": {
+        "description": "Cookie-based forward-auth gate for Caddy's `forward_auth` (deploy#458).\n\nValidates the parent-domain SSO cookie minted by `POST /auth/sso-cookie` and\nauthorizes admin-only access to the observability surface (Grafana):\n\n  - no / invalid / expired cookie  \u2192 401\n  - valid cookie, non-admin role   \u2192 403\n  - valid cookie, admin role       \u2192 200 + X-Webauth-User / X-Webauth-Role\n\nDistinct from the Bearer-only `GET /auth/token/validate`: this reads a *cookie*,\nnot an Authorization header, because the triggering request is a top-level\nbrowser navigation that carries no Bearer. The admin decision is made\nserver-side from the RS256-signed cookie claims \u2014 the client cannot forge it,\nand Caddy strips any client-supplied `X-Webauth-*` before this hop.",
+        "operationId": "forward_auth_auth_forward_auth_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForwardAuthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Forward Auth",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/auth/login": {
       "post": {
         "description": "Authenticate an email/password user and return a token pair.\n\nOn any failure (unknown email, wrong password, OAuth-only account, or a\ndeactivated account) the response is a single generic 401 so the endpoint\nnever reveals which emails are registered.",
@@ -2788,6 +2846,49 @@
           }
         },
         "summary": "Register",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/sso-cookie": {
+      "post": {
+        "description": "Mint a short-lived parent-domain SSO cookie from a valid app bearer.\n\nThe frontend calls this on a `/grafana` click (carrying its localStorage access\ntoken as a normal Bearer) so the *next* top-level browser navigation to a\nsibling subdomain (`isnad.{base}/grafana`) ships a credential Caddy's\n`forward_auth` can validate via `GET /auth/forward-auth`.\n\nAny authenticated user may mint \u2014 admin gating happens at forward-auth, not\nhere, so a non-admin still receives a cookie and is cleanly rejected (403) at\nthe Grafana edge rather than being unable to obtain a cookie at all. Roles are\nread authoritatively from the DB at mint time; the short TTL bounds staleness.",
+        "operationId": "issue_sso_cookie_auth_sso_cookie_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": true,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SsoCookieResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Issue Sso Cookie",
         "tags": [
           "auth"
         ]

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -148,6 +148,26 @@ class Settings(BaseSettings):
     # set to False in local HTTP dev.
     AUTH_OAUTH_REFRESH_COOKIE_SECURE: bool = True
 
+    # SSO session cookie — parent-domain carry for Caddy `forward_auth` (us#171 /
+    # deploy#458). A short-lived RS256-signed token minted from a valid app bearer
+    # (POST /auth/sso-cookie) and dropped as a parent-domain cookie so a top-level
+    # browser navigation to a sibling subdomain (e.g. isnad.{base}/grafana) carries
+    # a credential GET /auth/forward-auth can validate. The app access token lives
+    # only in SPA localStorage and is never sent on a top-level nav, which is why a
+    # cookie is needed here.
+    AUTH_SSO_COOKIE_NAME: str = "nl_sso"
+    # Parent domain so every *.noorinalabs.com subdomain receives the cookie. Owner
+    # accepted the widened cross-subdomain surface (us#171, 2026-06-14) in exchange
+    # for the short TTL + HttpOnly below. Override per-env (e.g. a staging base).
+    AUTH_SSO_COOKIE_DOMAIN: str = "noorinalabs.com"
+    # Short TTL (seconds) — bounds the window in which a role revoked after mint can
+    # still pass forward-auth (forward-auth trusts the signed claim, not a live DB
+    # read, so it stays cheap on every Grafana request). Keep small.
+    AUTH_SSO_COOKIE_TTL_SECONDS: int = 300
+    # Secure flag on the SSO cookie. Must be True in production (HTTPS); set to False
+    # only for local HTTP dev.
+    AUTH_SSO_COOKIE_SECURE: bool = True
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
     @computed_field  # type: ignore[prop-decorator]

--- a/src/app/routers/auth.py
+++ b/src/app/routers/auth.py
@@ -25,7 +25,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
 from jose.exceptions import JWTError
 from redis.asyncio import Redis
@@ -35,15 +35,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.app.config import Settings, get_settings
 from src.app.database import get_db_session, get_redis, get_redis_optional
+from src.app.dependencies import get_current_user
 from src.app.models.user import User
 from src.app.schemas.auth import (
     AuthProviderInfo,
+    ForwardAuthResponse,
     LoginRequest,
     OAuthLoginResponse,
     ProvidersResponse,
     RefreshRequest,
     RegisterRequest,
     RevokeRequest,
+    SsoCookieResponse,
     TokenRequest,
     TokenResponse,
     TokenValidationResponse,
@@ -55,11 +58,14 @@ from src.app.services.oauth import (
     is_oauth_provider_configured,
 )
 from src.app.services.rate_limit import check_rate_limit, enforce_ip_rate_limit
+from src.app.services.rbac import get_role_level, get_user_role_names, user_has_minimum_role
 from src.app.services.subscription import get_subscription_status
 from src.app.services.token import (
     create_access_token,
     create_refresh_token,
+    create_sso_token,
     decode_access_token,
+    decode_sso_token,
     revoke_refresh_token,
     store_refresh_token,
     validate_refresh_token,
@@ -110,6 +116,12 @@ OAUTH_ERROR_RATE_LIMITED = "rate_limited"
 OAUTH_ERROR_UPSERT_FAILED = "oauth_upsert_failed"
 
 VALID_PROVIDERS = {p.value for p in OAuthProvider}
+
+# Identity headers emitted by GET /auth/forward-auth on success. Caddy's
+# `forward_auth` copies these upstream to Grafana's auth-proxy (deploy#458), and
+# strips any client-supplied X-Webauth-* before this hop so they cannot be forged.
+WEBAUTH_USER_HEADER = "X-Webauth-User"
+WEBAUTH_ROLE_HEADER = "X-Webauth-Role"
 
 
 # --- Email / Password Endpoints ---
@@ -460,6 +472,117 @@ async def validate_token(
         subscription_status=payload.get("subscription_status"),
         expires_at=expires_at,
     )
+
+
+# --- SSO Session Cookie + Forward-Auth (us#171 / deploy#458) ---
+
+
+def _highest_role(roles: list[str]) -> str:
+    """Return the highest-privilege role name from a claim (for X-Webauth-Role).
+
+    Empty string when the user has no recognized role — never reached on the 200
+    path of forward-auth (which requires admin), but keeps the header well-defined.
+    """
+    return max(roles, key=get_role_level, default="")
+
+
+@router.post("/sso-cookie", response_model=SsoCookieResponse, status_code=status.HTTP_200_OK)
+async def issue_sso_cookie(
+    response: Response,
+    settings: SettingsDep,
+    db: DbDep,
+    user: Annotated[User, Depends(get_current_user)],
+) -> SsoCookieResponse:
+    """Mint a short-lived parent-domain SSO cookie from a valid app bearer.
+
+    The frontend calls this on a `/grafana` click (carrying its localStorage access
+    token as a normal Bearer) so the *next* top-level browser navigation to a
+    sibling subdomain (`isnad.{base}/grafana`) ships a credential Caddy's
+    `forward_auth` can validate via `GET /auth/forward-auth`.
+
+    Any authenticated user may mint — admin gating happens at forward-auth, not
+    here, so a non-admin still receives a cookie and is cleanly rejected (403) at
+    the Grafana edge rather than being unable to obtain a cookie at all. Roles are
+    read authoritatively from the DB at mint time; the short TTL bounds staleness.
+    """
+    roles = await get_user_role_names(db, user.id)
+    _token, _expires_at = create_sso_token(
+        settings=settings,
+        user_id=user.id,
+        email=user.email,
+        roles=roles,
+        ttl_seconds=settings.AUTH_SSO_COOKIE_TTL_SECONDS,
+    )
+    # Parent-domain + path=/ so the cookie rides every top-level nav to any
+    # *.{domain} subdomain. HttpOnly keeps it out of JS (the access token already
+    # covers same-origin fetches); Secure + SameSite=Lax per the owner-approved
+    # trade-off (us#171).
+    response.set_cookie(
+        key=settings.AUTH_SSO_COOKIE_NAME,
+        value=_token,
+        max_age=settings.AUTH_SSO_COOKIE_TTL_SECONDS,
+        domain=settings.AUTH_SSO_COOKIE_DOMAIN,
+        httponly=True,
+        secure=settings.AUTH_SSO_COOKIE_SECURE,
+        samesite="lax",
+        path="/",
+    )
+    return SsoCookieResponse(
+        cookie_name=settings.AUTH_SSO_COOKIE_NAME,
+        expires_in=settings.AUTH_SSO_COOKIE_TTL_SECONDS,
+    )
+
+
+@router.get("/forward-auth", response_model=ForwardAuthResponse)
+async def forward_auth(
+    request: Request,
+    response: Response,
+    settings: SettingsDep,
+) -> ForwardAuthResponse:
+    """Cookie-based forward-auth gate for Caddy's `forward_auth` (deploy#458).
+
+    Validates the parent-domain SSO cookie minted by `POST /auth/sso-cookie` and
+    authorizes admin-only access to the observability surface (Grafana):
+
+      - no / invalid / expired cookie  → 401
+      - valid cookie, non-admin role   → 403
+      - valid cookie, admin role       → 200 + X-Webauth-User / X-Webauth-Role
+
+    Distinct from the Bearer-only `GET /auth/token/validate`: this reads a *cookie*,
+    not an Authorization header, because the triggering request is a top-level
+    browser navigation that carries no Bearer. The admin decision is made
+    server-side from the RS256-signed cookie claims — the client cannot forge it,
+    and Caddy strips any client-supplied `X-Webauth-*` before this hop.
+    """
+    cookie = request.cookies.get(settings.AUTH_SSO_COOKIE_NAME)
+    if not cookie:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing SSO session cookie",
+        )
+
+    try:
+        payload = decode_sso_token(settings, cookie)
+    except JWTError as err:
+        # Bad signature, wrong token type, or expiry — all collapse to 401 so the
+        # endpoint never distinguishes "no cookie" from "forged/stale cookie".
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired SSO session cookie",
+        ) from err
+
+    roles: list[str] = payload.get("roles", [])
+    if not user_has_minimum_role(roles, "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+    # Identity for Grafana's auth-proxy. Prefer email (a human-friendly login);
+    # fall back to the user id (`sub`) if the cookie carried no email.
+    response.headers[WEBAUTH_USER_HEADER] = str(payload.get("email") or payload.get("sub", ""))
+    response.headers[WEBAUTH_ROLE_HEADER] = _highest_role(roles)
+    return ForwardAuthResponse()
 
 
 # --- OAuth Endpoints ---

--- a/src/app/schemas/auth.py
+++ b/src/app/schemas/auth.py
@@ -102,6 +102,33 @@ class TokenValidationResponse(BaseModel):
     expires_at: datetime | None = None
 
 
+class SsoCookieResponse(BaseModel):
+    """Acknowledgement for `POST /auth/sso-cookie`.
+
+    The credential itself rides in the `Set-Cookie` header — the body only echoes
+    the cookie name and lifetime so the frontend can schedule a re-mint before the
+    short TTL lapses (us#171).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str = "ok"
+    cookie_name: str
+    expires_in: int
+
+
+class ForwardAuthResponse(BaseModel):
+    """Body for a successful `GET /auth/forward-auth`.
+
+    The load-bearing output is the `X-Webauth-User` / `X-Webauth-Role` response
+    headers that Caddy copies upstream to Grafana; the body is a minimal ack.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str = "ok"
+
+
 class JWK(BaseModel):
     """JSON Web Key representation."""
 

--- a/src/app/services/token.py
+++ b/src/app/services/token.py
@@ -40,6 +40,53 @@ def create_access_token(
     return token, expires_at
 
 
+def create_sso_token(
+    settings: Settings,
+    user_id: uuid.UUID,
+    email: str,
+    roles: list[str],
+    ttl_seconds: int,
+) -> tuple[str, datetime]:
+    """Create a short-lived RS256 SSO cookie token. Returns (token, expires_at).
+
+    Carries the user id (`sub`), email, and role names so the cookie-based
+    `GET /auth/forward-auth` gate (Caddy `forward_auth`, us#171 / deploy#458) can
+    authorize without a DB round-trip on every upstream request. Tagged
+    `type="sso"` and decoded only by ``decode_sso_token`` so an access token can
+    never be replayed as a forward-auth cookie, nor vice versa.
+    """
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    payload: dict[str, Any] = {
+        "sub": str(user_id),
+        "email": email,
+        "roles": roles,
+        "iat": now,
+        "exp": expires_at,
+        "type": "sso",
+    }
+    private_key = get_private_key(settings)
+    token: str = jwt.encode(payload, private_key, algorithm=settings.JWT_ALGORITHM)
+    return token, expires_at
+
+
+def decode_sso_token(settings: Settings, token: str) -> dict[str, Any]:
+    """Decode and validate an SSO cookie token. Raises JWTError on failure.
+
+    Signature + expiry are verified by ``jwt.decode``; the explicit ``type`` check
+    rejects any non-SSO token (e.g. a leaked access token) presented as a cookie.
+    """
+    public_key = get_public_key(settings)
+    payload: dict[str, Any] = jwt.decode(
+        token,
+        public_key,
+        algorithms=[settings.JWT_ALGORITHM],
+    )
+    if payload.get("type") != "sso":
+        raise JWTError("Not an SSO token")
+    return payload
+
+
 def create_refresh_token() -> str:
     """Create a cryptographically random refresh token."""
     return secrets.token_urlsafe(48)

--- a/tests/test_sso_forward_auth.py
+++ b/tests/test_sso_forward_auth.py
@@ -1,0 +1,373 @@
+"""Tests for the parent-domain SSO session cookie + GET /auth/forward-auth.
+
+Covers the user-service third of the deploy#458 admin-gated-Grafana feature
+(us#171):
+
+  * POST /auth/sso-cookie — authenticated mint of a short-lived, RS256-signed
+    parent-domain cookie (attributes + TTL + signature + claims).
+  * GET /auth/forward-auth — cookie-based gate Caddy's forward_auth calls:
+    200 + X-Webauth-* for an admin with a valid cookie, 401 for no/invalid/expired
+    cookie, 403 for a valid cookie whose user is not an admin.
+"""
+
+import re
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.app.config import Settings, get_settings
+from src.app.database import get_db_session
+from src.app.main import create_app
+from src.app.models.role import Role, UserRole
+from src.app.models.user import Base, User
+from src.app.services.token import create_sso_token
+
+# --- Test RSA keypair (the service's signing/verification key for these tests) ---
+_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+TEST_PRIVATE_PEM = _test_private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode()
+TEST_PUBLIC_PEM = (
+    _test_private_key.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+# A *different* keypair — used to forge a cookie the service must reject.
+_other_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+OTHER_PRIVATE_PEM = _other_private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode()
+
+COOKIE_NAME = "nl_sso"
+
+
+def _test_settings() -> Settings:
+    return Settings(
+        JWT_PRIVATE_KEY=TEST_PRIVATE_PEM,
+        JWT_PUBLIC_KEY=TEST_PUBLIC_PEM,
+        DATABASE_URL="sqlite+aiosqlite://",
+    )
+
+
+def _access_token(user_id: uuid.UUID, roles: list[str] | None = None) -> str:
+    """Mint an app access token (the Bearer the mint endpoint authenticates)."""
+    payload: dict[str, object] = {
+        "sub": str(user_id),
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "type": "access",
+    }
+    if roles:
+        payload["roles"] = roles
+    return jwt.encode(payload, TEST_PRIVATE_PEM, algorithm="RS256")
+
+
+def _sso_cookie_token(
+    *,
+    user_id: uuid.UUID | None = None,
+    email: str = "admin@test.com",
+    roles: list[str] | None = None,
+    ttl_seconds: int = 300,
+    private_pem: str = TEST_PRIVATE_PEM,
+    token_type: str = "sso",
+) -> str:
+    """Build an SSO cookie token directly for forward-auth unit coverage."""
+    now = datetime.now(UTC)
+    payload: dict[str, object] = {
+        "sub": str(user_id or uuid.uuid4()),
+        "email": email,
+        "roles": roles if roles is not None else ["admin"],
+        "iat": now,
+        "exp": now + timedelta(seconds=ttl_seconds),
+        "type": token_type,
+    }
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+@pytest.fixture
+async def db_engine():  # type: ignore[no-untyped-def]
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def db_session(db_engine) -> AsyncGenerator[AsyncSession, None]:  # type: ignore[no-untyped-def, type-arg]
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture
+async def seed_roles(db_session: AsyncSession) -> dict[str, Role]:
+    roles = {}
+    for name, desc in [
+        ("admin", "Full platform administration access"),
+        ("researcher", "Access to research tools and datasets"),
+        ("reader", "Read-only access to public content"),
+        ("trial", "Time-limited trial access"),
+    ]:
+        role = Role(name=name, description=desc)
+        db_session.add(role)
+        roles[name] = role
+    await db_session.commit()
+    return roles
+
+
+@pytest.fixture
+async def admin_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
+    user = User(email="admin@test.com", display_name="Admin", email_verified=True, is_active=True)
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=user.id, role_id=seed_roles["admin"].id, granted_by=user.id))
+    await db_session.commit()
+    return user
+
+
+@pytest.fixture
+async def regular_user(db_session: AsyncSession, seed_roles: dict[str, Role]) -> User:
+    user = User(email="reader@test.com", display_name="Reader", email_verified=True, is_active=True)
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=user.id, role_id=seed_roles["reader"].id))
+    await db_session.commit()
+    return user
+
+
+@pytest.fixture
+async def client(
+    db_engine,  # type: ignore[no-untyped-def]
+    db_session: AsyncSession,
+) -> AsyncGenerator[AsyncClient, None]:
+    app = create_app()
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_settings] = _test_settings
+    app.dependency_overrides[get_db_session] = _override_db
+
+    transport = ASGITransport(app=app)  # type: ignore[arg-type]
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _cookie_value(set_cookie_header: str) -> str:
+    match = re.search(rf"{COOKIE_NAME}=([^;]+)", set_cookie_header)
+    assert match is not None, f"no {COOKIE_NAME} cookie in: {set_cookie_header!r}"
+    return match.group(1)
+
+
+# --- Mint endpoint -----------------------------------------------------------
+
+
+class TestMintSsoCookie:
+    @pytest.mark.asyncio
+    async def test_admin_gets_cookie_with_security_attributes(
+        self, client: AsyncClient, admin_user: User
+    ) -> None:
+        resp = await client.post(
+            "/auth/sso-cookie",
+            headers={"Authorization": f"Bearer {_access_token(admin_user.id)}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"status": "ok", "cookie_name": COOKIE_NAME, "expires_in": 300}
+
+        set_cookie = resp.headers["set-cookie"].lower()
+        assert f"{COOKIE_NAME}=" in set_cookie
+        assert "domain=noorinalabs.com" in set_cookie
+        assert "httponly" in set_cookie
+        assert "secure" in set_cookie
+        assert "samesite=lax" in set_cookie
+        assert "max-age=300" in set_cookie
+        assert "path=/" in set_cookie
+
+    @pytest.mark.asyncio
+    async def test_minted_token_is_signed_and_carries_claims(
+        self, client: AsyncClient, admin_user: User
+    ) -> None:
+        resp = await client.post(
+            "/auth/sso-cookie",
+            headers={"Authorization": f"Bearer {_access_token(admin_user.id)}"},
+        )
+        token = _cookie_value(resp.headers["set-cookie"])
+        # Verifiable with the service public key — i.e. genuinely RS256-signed.
+        payload = jwt.decode(token, TEST_PUBLIC_PEM, algorithms=["RS256"])
+        assert payload["type"] == "sso"
+        assert payload["sub"] == str(admin_user.id)
+        assert payload["email"] == admin_user.email
+        assert payload["roles"] == ["admin"]
+        # TTL ~ 300s in the future.
+        ttl = payload["exp"] - payload["iat"]
+        assert ttl == 300
+
+    @pytest.mark.asyncio
+    async def test_non_admin_also_receives_a_cookie(
+        self, client: AsyncClient, regular_user: User
+    ) -> None:
+        # Any authenticated user may mint — admin gating is enforced at
+        # forward-auth (403), not at the mint endpoint.
+        resp = await client.post(
+            "/auth/sso-cookie",
+            headers={"Authorization": f"Bearer {_access_token(regular_user.id)}"},
+        )
+        assert resp.status_code == 200
+        token = _cookie_value(resp.headers["set-cookie"])
+        payload = jwt.decode(token, TEST_PUBLIC_PEM, algorithms=["RS256"])
+        assert payload["roles"] == ["reader"]
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_rejected(self, client: AsyncClient) -> None:
+        resp = await client.post("/auth/sso-cookie")
+        assert resp.status_code in (401, 422)
+
+    @pytest.mark.asyncio
+    async def test_invalid_bearer_rejected(self, client: AsyncClient) -> None:
+        resp = await client.post("/auth/sso-cookie", headers={"Authorization": "Bearer not-a-jwt"})
+        assert resp.status_code == 401
+
+
+# --- Forward-auth gate -------------------------------------------------------
+
+
+class TestForwardAuth:
+    @pytest.mark.asyncio
+    async def test_admin_valid_cookie_200_with_headers(self, client: AsyncClient) -> None:
+        uid = uuid.uuid4()
+        token = _sso_cookie_token(user_id=uid, email="admin@test.com", roles=["admin"])
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 200
+        assert resp.headers["x-webauth-user"] == "admin@test.com"
+        assert resp.headers["x-webauth-role"] == "admin"
+
+    @pytest.mark.asyncio
+    async def test_user_header_falls_back_to_sub_when_no_email(self, client: AsyncClient) -> None:
+        uid = uuid.uuid4()
+        token = _sso_cookie_token(user_id=uid, email="", roles=["admin"])
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 200
+        assert resp.headers["x-webauth-user"] == str(uid)
+
+    @pytest.mark.asyncio
+    async def test_no_cookie_401(self, client: AsyncClient) -> None:
+        resp = await client.get("/auth/forward-auth")
+        assert resp.status_code == 401
+        assert "x-webauth-user" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_garbage_cookie_401(self, client: AsyncClient) -> None:
+        resp = await client.get(
+            "/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}=not-a-jwt"}
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_foreign_signature_401(self, client: AsyncClient) -> None:
+        # Correctly-shaped SSO token, but signed by a key the service doesn't trust.
+        token = _sso_cookie_token(roles=["admin"], private_pem=OTHER_PRIVATE_PEM)
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_type_401(self, client: AsyncClient) -> None:
+        # An access token (type=access) replayed as the SSO cookie must be rejected.
+        token = _sso_cookie_token(roles=["admin"], token_type="access")
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_expired_cookie_401(self, client: AsyncClient) -> None:
+        token = _sso_cookie_token(roles=["admin"], ttl_seconds=-10)
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_non_admin_403(self, client: AsyncClient) -> None:
+        token = _sso_cookie_token(roles=["reader"])
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 403
+        assert "x-webauth-user" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_no_roles_403(self, client: AsyncClient) -> None:
+        token = _sso_cookie_token(roles=[])
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 403
+
+
+# --- End-to-end --------------------------------------------------------------
+
+
+class TestMintThenForwardAuth:
+    @pytest.mark.asyncio
+    async def test_admin_roundtrip(self, client: AsyncClient, admin_user: User) -> None:
+        mint = await client.post(
+            "/auth/sso-cookie",
+            headers={"Authorization": f"Bearer {_access_token(admin_user.id)}"},
+        )
+        token = _cookie_value(mint.headers["set-cookie"])
+
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 200
+        assert resp.headers["x-webauth-user"] == admin_user.email
+        assert resp.headers["x-webauth-role"] == "admin"
+
+    @pytest.mark.asyncio
+    async def test_non_admin_roundtrip_403(self, client: AsyncClient, regular_user: User) -> None:
+        mint = await client.post(
+            "/auth/sso-cookie",
+            headers={"Authorization": f"Bearer {_access_token(regular_user.id)}"},
+        )
+        token = _cookie_value(mint.headers["set-cookie"])
+
+        resp = await client.get("/auth/forward-auth", headers={"Cookie": f"{COOKIE_NAME}={token}"})
+        assert resp.status_code == 403
+
+
+def test_sso_token_service_roundtrip() -> None:
+    """create_sso_token → decode_sso_token returns the same claims."""
+    from src.app.services.token import decode_sso_token
+
+    settings = _test_settings()
+    uid = uuid.uuid4()
+    token, expires_at = create_sso_token(
+        settings=settings,
+        user_id=uid,
+        email="x@test.com",
+        roles=["admin"],
+        ttl_seconds=300,
+    )
+    payload = decode_sso_token(settings, token)
+    assert payload["sub"] == str(uid)
+    assert payload["email"] == "x@test.com"
+    assert payload["roles"] == ["admin"]
+    assert payload["type"] == "sso"
+    assert isinstance(expires_at, datetime)


### PR DESCRIPTION
## What & why

User-service third of **deploy#458** (admin-gated Grafana via Caddy `forward_auth`). Owner approved the **parent-domain session-cookie** carry on 2026-06-14. The app access token lives only in the SPA's localStorage and rides as `Authorization: Bearer` on fetches — a top-level browser navigation to `isnad.{base}/grafana` carries no Authorization header and no cookie, so `forward_auth` has nothing to validate. This PR supplies the cookie + the cookie-based validation endpoint.

Closes #171. Meta: noorinalabs-main#681. Frontend companion: ig#1081.

## Contract (for the frontend ig#1081 + Caddy deploy#458)

**Mint — `POST /auth/sso-cookie`** (authenticated; send the app access token as `Authorization: Bearer <token>`)
- Any authenticated user may mint (admin gating is at forward-auth, so a non-admin still gets a cookie and is cleanly 403'd at the Grafana edge).
- Response: `200` with body `{"status":"ok","cookie_name":"nl_sso","expires_in":300}` and a `Set-Cookie`:
  - name `nl_sso`, `Domain=noorinalabs.com`, `HttpOnly`, `Secure`, `SameSite=Lax`, `Max-Age=300`, `Path=/`
  - value = RS256-signed JWT (same keypair as the app JWT), `type="sso"`, claims `sub` (user id), `email`, `roles`.
- Frontend: call this on a `/grafana` click, then do the top-level navigation. Re-mint before the 300s TTL lapses.

**Validate — `GET /auth/forward-auth`** (cookie-based; this is what the Caddy `forward_auth` directive calls)
- Valid cookie + admin role → `200` + headers `X-Webauth-User` (email, falls back to user id) and `X-Webauth-Role` (highest role, i.e. `admin`).
- No / invalid / expired / wrong-type cookie → `401`.
- Valid cookie, non-admin → `403`.
- Admin decided **server-side** from the RS256-signed claim; never trusts client headers. Caddy strips client-supplied `X-Webauth-*` before this hop (deploy#458).

**Config** (`.env.example`): `AUTH_SSO_COOKIE_NAME` (`nl_sso`), `AUTH_SSO_COOKIE_DOMAIN` (`noorinalabs.com`), `AUTH_SSO_COOKIE_TTL_SECONDS` (`300`), `AUTH_SSO_COOKIE_SECURE` (`true`; set `false` for local HTTP).

## Security posture

- Short TTL (5 min) bounds post-revocation staleness — forward-auth trusts the signed claim rather than a per-request DB read, keeping the high-frequency gate cheap. Roles are read authoritatively from the DB at **mint** time.
- `type="sso"` separation: an access token can't be replayed as a forward-auth cookie and vice versa (`decode_sso_token` rejects any non-sso type).
- HttpOnly keeps the cookie out of JS; Secure + SameSite=Lax; signature verified with the service public key.
- Parent-domain scoping widens the surface to every `*.noorinalabs.com` subdomain — owner-accepted trade-off (us#171).

## No schema change

Cookie + endpoint logic only — no Alembic migration (rebased onto #165/PR#170's migration 0042; no conflicting head).

## Test Plan

- `tests/test_sso_forward_auth.py` — 17 tests, all green:
  - Mint: security attributes (Domain/HttpOnly/Secure/SameSite=Lax/Max-Age/Path), TTL=300, RS256 signature verifiable with the service key, claims (`sub`/`email`/`roles`/`type=sso`), non-admin still gets a cookie, unauthenticated/invalid-bearer rejected.
  - Forward-auth: admin 200 + both headers, `X-Webauth-User` email→sub fallback, no-cookie 401, garbage 401, foreign-signature 401, wrong-type (access) 401, expired 401, non-admin 403, no-roles 403.
  - End-to-end mint→forward-auth roundtrip (admin 200, non-admin 403).
  - Token-service `create_sso_token`→`decode_sso_token` roundtrip.
- `make check` (ruff lint + format, mypy strict, full pytest): **376 passed, 4 skipped**.
- OpenAPI snapshot regenerated; drift gate clean.

> Do NOT promote `forward_auth` to stg/prod until this ships — hard cutover (Grafana's own login becomes unreachable through Caddy). Coordinated in deploy#458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
