### PR TITLE
docs(README): document required pre-commit + pre-push hook install (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# noorinalabs-user-service
+
+User/auth/RBAC service — JWT issuer, OAuth, sessions; FastAPI + Postgres.
+
+This repo houses the FastAPI app (`src/`), its test suite (`tests/`), Alembic
+migrations, and the OpenAPI snapshot under `docs/`.
+
+## Git hooks (required)
+
+This repo mirrors its CI checks locally via [pre-commit](https://pre-commit.com/).
+After cloning, install BOTH hook stages once:
+
+```bash
+uvx pre-commit install                       # commit-stage checks
+uvx pre-commit install --hook-type pre-push  # push-stage checks
+```
+
+- **Commit stage** runs: `ruff-format`, `ruff-lint` (`ruff --fix`), and
+  `actionlint` over the workflow files.
+- **Pre-push stage** runs: `mypy` (strict, over `src/`) and the `pytest` suite.
+
+These mirror `.github/workflows/ci.yml` (and the docs/config gate in
+`.github/workflows/docs.yml`) so failures surface locally before a PR — org-wide
+local⇄CI parity, noorinalabs-main#684. Never bypass with `--no-verify`.
+
+Notes:
+
+- `actionlint` shells out to `shellcheck`; install `shellcheck` on your PATH or
+  the embedded shellcheck integration is silently skipped (local "clean" then
+  diverges from CI).
+- If `pre-commit install` "cowardly refuses" because `core.hooksPath` is set,
+  run `git config --unset core.hooksPath` first.


### PR DESCRIPTION
## Summary

Adds a root `README.md` for `noorinalabs-user-service` (the repo had none),
anchored on a **Git hooks (required)** section as requested by the issue.

The hooks section enumerates the *real* hooks per stage, read from
`.pre-commit-config.yaml` at HEAD:

- **Commit stage:** `ruff-format`, `ruff-lint` (`ruff --fix`), `actionlint`
- **Pre-push stage:** `mypy` (strict, `src/`) + `pytest`

It documents installing **both** hook stages, the `shellcheck`-on-PATH
prerequisite for `actionlint`, and the `core.hooksPath` unset workaround —
mirroring `.github/workflows/ci.yml` + `docs.yml` for org-wide local⇄CI parity
(noorinalabs-main#684). Never bypass with `--no-verify`.

## Verification

- `markdownlint-cli2` (repo `.markdownlint-cli2.jsonc`): 0 errors
- `pre-commit run --files README.md`: pass (ruff/actionlint skip — no relevant files)
- pre-push stage (`mypy` + `pytest`) ran clean on push
- README is outside the `cspell` `files` scope and has no relative links (lychee-safe)

Reviewers: needs **2 reviewers** per charter.

Closes #180
