### PR TITLE
tech-debt(ci-parity): mirror cspell into pre-commit + classify cspell kind (rollout of main#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -23,11 +23,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, noorinalabs-main#684) so a CI job that runs it
+starts demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -64,6 +68,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+    # `cspell` closes the spell-check blind spot (noorinalabs-main#684): docs.yml's
+    # `Spellcheck (cspell)` job runs the `streetsidesoftware/cspell-action` (or a
+    # `cspell` CLI), but until this kind existed an un-classified spell gate
+    # produced ZERO drift signal, so the repo could enforce cspell in CI with no
+    # pre-commit mirror — new domain vocabulary then failed only after push.
+    # Patterns cover the action ref, the bundled-CLI step name, and the generic
+    # job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -111,6 +111,62 @@ jobs:
         self.assertNotIn("ruff-lint", kinds)
 
 
+class CspellKindClassification(unittest.TestCase):
+    """The `cspell` kind closes the spell-check blind spot (noorinalabs-main#684):
+    docs.yml's `Spellcheck (cspell)` job must be classified so the drift gate
+    DEMANDS a pre-commit mirror, and the pre-commit `cspell` hook must classify
+    back to the same kind so the two sides compare equal."""
+
+    def test_ci_cspell_action_detected(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_ci_cspell_cli_run_detected(self) -> None:
+        # A repo expressing the same gate as a CLI `run:` step must also classify.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - run: cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_precommit_cspell_hook_detected(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_cspell_mirror_no_drift(self) -> None:
+        # CI enforces cspell and pre-commit mirrors it -> no harmful drift.
+        harmful, stricter = compute_drift(
+            precommit_kinds={"cspell"},
+            ci_kinds={"cspell"},
+        )
+        self.assertEqual(harmful, set())
+        self.assertEqual(stricter, set())
+
+    def test_cspell_ci_only_is_harmful(self) -> None:
+        # CI enforces cspell but pre-commit does not -> the blind spot this fix
+        # closes is now a real drift signal.
+        harmful, _ = compute_drift(
+            precommit_kinds=set(),
+            ci_kinds={"cspell"},
+        )
+        self.assertIn("cspell", harmful)
+
+
 class DriftDirection(unittest.TestCase):
     def test_ci_enforced_not_local_is_harmful(self) -> None:
         harmful, stricter = compute_drift(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,27 @@ repos:
       - id: actionlint
         name: actionlint
 
+  # cspell mirrors docs.yml's `Spellcheck (cspell)` job so the sync-drift gate
+  # (which globs ALL workflows and now classifies the `cspell` kind — #684)
+  # stays green. New domain vocabulary then fails `pre-commit run` locally
+  # instead of only surfacing as a CI red after push. Pinned to v8.4.0 of
+  # cspell-cli to match the exact cspell the
+  # `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles — same engine +
+  # dictionaries on both sides. `language: node`, so pre-commit provisions its
+  # own node/cspell env (no system cspell required).
+  #
+  # `files` is the regex equivalent of the CI action's authored-prose glob set
+  # (CLAUDE.md, docs/**/*.md, the team charter); `--config .cspell.json` reuses
+  # the same dictionaries + ignore rules CI loads, so a word that passes locally
+  # passes in CI and vice-versa.
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(CLAUDE\.md|docs/.*\.md|\.claude/team/charter\.md)$
+
   # Heavier checks run at pre-push (mirror CI's pytest job + the strict mypy from
   # `make check`). Run as `local`/`system` hooks via `uv run` so the pinned
   # tools from uv.lock are used and never drift from CI.


### PR DESCRIPTION
## Summary

Rollout of **noorinalabs-main#684** (full local⇄CI tooling parity) to `noorinalabs-user-service`: close the cspell blind spot in the pre-commit ⇄ CI sync-drift gate and mirror the CI spellcheck into pre-commit so new domain vocabulary fails locally instead of only as a CI red after push.

## Changes

**Part 1 — classify the `cspell` kind (`.claude/lib/pre_commit_ci_sync.py`)**
- Add `"cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell")` to `_KIND_PATTERNS` (patterns cover the action ref, the bundled-CLI step name, and the generic job/step word). Until now an un-classified spell gate produced zero drift signal, so the gate could not demand a pre-commit mirror.
- New `CspellKindClassification` test class covering: CI action-ref form, CI CLI `run:` form, the pre-commit hook id, plus the no-drift and CI-only-is-harmful directions.

**Part 2 — mirror the cspell hook (`.pre-commit-config.yaml`)**
- Pinned `streetsidesoftware/cspell-cli` at **v8.4.0**, matching the exact engine the `streetsidesoftware/cspell-action@…v8.4.0` step in `docs.yml` bundles.
- Scoped via `files` to the regex equivalent of the CI action's authored-prose glob set: `^(CLAUDE\.md|docs/.*\.md|\.claude/team/charter\.md)$`.
- `--config .cspell.json` reuses the same dictionaries + ignore rules CI loads, so a word that passes locally passes in CI and vice-versa.

No additions to `.cspell/project-words.txt` were needed — the authored prose passes clean.

## Verification

- `python3 .claude/lib/pre_commit_ci_sync.py . --ci .github/workflows/ci.yml --ci .github/workflows/docs.yml` → `OK` (rc=0), CI's exact scoping.
- `python3 -m pytest .claude/lib/tests/test_pre_commit_ci_sync.py -q` → 16 passed.
- `pre-commit run --all-files` → ruff-format / ruff-lint / actionlint / cspell all Passed.
- Pre-push mypy + pytest passed on push.

cspell version pinned: **v8.4.0** (cspell-cli, matching the CI cspell-action).

Closes #188
Part of noorinalabs-main#684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2U19RpdPtzAv8qfjQwacx
