### PR TITLE
ci: run RUN_PG_CONTAINER_TESTS Postgres tests in CI (#187)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,30 @@ jobs:
       - run: uv run ruff format --check .
       - run: uv run pytest
 
+  pg-container-tests:
+    name: Postgres container tests (RUN_PG_CONTAINER_TESTS)
+    # The real-Postgres container tests (testcontainers + Docker) gated behind
+    # RUN_PG_CONTAINER_TESTS=1 run NOWHERE in the default `check` job — it leaves
+    # the flag unset so they skip (kept fast/deterministic). This job is their
+    # automated home (#187): GitHub-hosted ubuntu runners ship a Docker daemon,
+    # so testcontainers can start its own throwaway `postgres:16-alpine` — no
+    # `services:` block needed. The tests still degrade to a SKIP (never a red
+    # build) if Docker is unavailable, so this job is a strict superset of value.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync --extra dev
+      - name: Run real-Postgres container tests
+        env:
+          RUN_PG_CONTAINER_TESTS: "1"
+          ENVIRONMENT: test
+        run: >-
+          uv run pytest
+          tests/test_bootstrap_admin.py
+          tests/test_oauth_account_linking_guard_pg.py
+          -v
+
   openapi-snapshot-drift:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The 4 real-Postgres container tests gated behind `RUN_PG_CONTAINER_TESTS=1` ran **nowhere** in CI — the default `check` job leaves the flag unset, so they skip. Admin-grant and OAuth-account-linking Postgres behaviour was therefore unvalidated by any automated run (local opt-in proofs only).

This adds a dedicated **`pg-container-tests`** CI job that sets `RUN_PG_CONTAINER_TESTS=1` (+ `ENVIRONMENT=test`) and runs the two gated files:
- `tests/test_bootstrap_admin.py::TestGrantAdminPostgres`
- `tests/test_oauth_account_linking_guard_pg.py` (3 cross-method-guard proofs)

### Why no `services: postgres`
The tests self-provision via **testcontainers** — they start their own throwaway `postgres:16-alpine`. GitHub-hosted `ubuntu-latest` runners ship a Docker daemon, so no `services:` block is needed. The tests already degrade to a **SKIP** (never a red build) if Docker is unavailable, so the job is a strict superset of value.

### Sync-drift gate
The new job classifies as the `pytest` kind, already mirrored in the pre-commit push stage, so `Pre-commit ⇄ CI sync-drift gate` stays green (verified locally: `OK: pre-commit config mirrors all CI-enforced checks`).

### Validation
Ran locally with Docker — all 4 PG container tests pass (21 passed total across the two files in 9.13s).

Closes #187

TechDebt: none — this closes a coverage gap (integration-grade tests that existed but ran nowhere automated); no new debt introduced.
