### PR TITLE
ci(base-pin): roll check_dockerfile_base_pin into user-service CI + pre-commit (#744)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -24,7 +24,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell
+    cspell, dockerfile-base-pin
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -76,6 +76,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # Patterns cover the action ref, the bundled-CLI step name, and the generic
     # job/step word.
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # `dockerfile-base-pin` is the charter-prose→code gate built in
+    # noorinalabs-main#735 and rolled out to this image-building repo via #744:
+    # a `.claude/lib/check_dockerfile_base_pin.py` invoked identically by a CI
+    # step and a pre-commit hook. Classifying it makes the drift gate DEMAND the
+    # pre-commit mirror (the #684 contract: an un-classified CI check is a silent
+    # blind spot). Patterns match the script basename (present on both sides'
+    # invoke line) and the hook id / job name.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -1,0 +1,195 @@
+"""Tests for check_dockerfile_base_pin — the Base Image Pinning gate (#735).
+
+Verifies the deterministic conversion of `tech-decisions.md § Base Image
+Pinning`: every FROM must be digest-pinned AND carry the matching distro
+upgrade, with the section's exact exemptions (scratch, distroless, stage
+references, vendor `# RATIONALE:`). Positive cases use the real required pattern
+the section documents; negative cases use the exact prohibited shapes it names
+(floating tag, pin-only, apk-only).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_dockerfile_base_pin import (
+    check_dockerfile_text,
+    main,
+    parse_froms,
+)
+
+# A real digest (truncated only for readability is NOT allowed by the checker —
+# it needs the literal `@sha256:` marker, which these carry in full shape).
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+
+
+class CompliantFromsPass(unittest.TestCase):
+    def test_alpine_pinned_with_apk_upgrade(self) -> None:
+        df = f"""# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_debian_slim_pinned_with_apt_upgrade(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST}
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_distroless_pin_only_is_sufficient(self) -> None:
+        # Distroless has no package manager — pinned-only passes, no upgrade.
+        df = f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_scratch_final_layer_exempt(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM scratch
+COPY --from=builder /app /app
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_stage_reference_inherits_pin(self) -> None:
+        # `FROM builder` references an earlier stage; it inherits the pin and is
+        # not re-checked for a digest or an upgrade.
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get clean
+
+FROM builder
+RUN pip install .
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_inline_comment_exempts(self) -> None:
+        df = "FROM vendor/proprietary:1.4  # RATIONALE: not redistributable digest-pinned\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_preceding_comment_exempts(self) -> None:
+        df = """# RATIONALE: vendor image, not available as a digest-pinned ref
+FROM vendor/proprietary:1.4
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_platform_flag_is_stripped(self) -> None:
+        df = f"""FROM --platform=linux/amd64 node:20-alpine{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class ProhibitedShapesFlagged(unittest.TestCase):
+    def test_floating_tag_flagged(self) -> None:
+        # WRONG (floating tag): no digest, no upgrade — both defenses missing.
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertTrue(any("Alpine upgrade" in v for v in violations))
+
+    def test_pin_only_alpine_missing_upgrade(self) -> None:
+        # INSUFFICIENT (pin-only): tag frozen but Alpine packages drift — the
+        # exact shape isnad-graph#853 hit.
+        df = f"FROM nginx:stable-alpine3.23{_DIGEST}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Alpine upgrade", violations[0])
+
+    def test_apk_only_missing_digest(self) -> None:
+        # INSUFFICIENT (apk-only): upgrade present but base layer is unpinned.
+        df = "FROM nginx:alpine\nRUN apk upgrade --no-cache\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not digest-pinned", violations[0])
+
+    def test_debian_pinned_missing_apt_upgrade(self) -> None:
+        df = f"FROM python:3.12-slim{_DIGEST}\nRUN pip install .\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_apt_update_only_is_not_an_upgrade(self) -> None:
+        # `apt-get update` is not `apt-get upgrade`; pin present, upgrade absent.
+        df = f"FROM debian:bookworm-slim{_DIGEST}\nRUN apt-get update\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_line_number_reported(self) -> None:
+        df = """# header comment
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Dockerfile:2:", violations[0])
+
+
+class MultiStageMixed(unittest.TestCase):
+    def test_compliant_builder_but_bad_runtime_flags_only_runtime(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM nginx:alpine
+COPY --from=builder /app /app
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        # builder is clean; only the floating runtime FROM is flagged (pin+upgrade).
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(all("FROM nginx:alpine" in v for v in violations))
+
+
+class ParserBehavior(unittest.TestCase):
+    def test_parse_collects_stage_names_and_images(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+FROM scratch
+"""
+        froms = parse_froms(df)
+        self.assertEqual(len(froms), 2)
+        self.assertEqual(froms[0].stage, "builder")
+        self.assertTrue(froms[0].image.startswith("python:3.12-slim@sha256:"))
+        self.assertEqual(froms[1].image, "scratch")
+
+    def test_from_keyword_case_insensitive(self) -> None:
+        df = f"from nginx:alpine{_DIGEST} as web\nRUN apk upgrade --no-cache\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class CliBehavior(unittest.TestCase):
+    def test_clean_file_exits_zero(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(f"FROM nginx:stable-alpine3.23{_DIGEST}\nRUN apk upgrade --no-cache\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_exits_one(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write("FROM nginx:alpine\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -167,6 +167,47 @@ repos:
         self.assertIn("cspell", harmful)
 
 
+class DockerfileBasePinKindClassification(unittest.TestCase):
+    """The `dockerfile-base-pin` kind (noorinalabs-main#735, rolled out by #744)
+    must classify from BOTH sides — the CI `run:` step and the pre-commit hook
+    id — so the drift gate DEMANDS the mirror and the two sides compare equal."""
+
+    def test_ci_base_pin_run_step_detected(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_ci(wf))
+
+    def test_precommit_base_pin_hook_detected(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_precommit(cfg))
+
+    def test_base_pin_mirror_no_drift(self) -> None:
+        harmful, stricter = compute_drift(
+            precommit_kinds={"dockerfile-base-pin"},
+            ci_kinds={"dockerfile-base-pin"},
+        )
+        self.assertEqual(harmful, set())
+        self.assertEqual(stricter, set())
+
+    def test_base_pin_ci_only_is_harmful(self) -> None:
+        harmful, _ = compute_drift(
+            precommit_kinds=set(),
+            ci_kinds={"dockerfile-base-pin"},
+        )
+        self.assertIn("dockerfile-base-pin", harmful)
+
+
 class DriftDirection(unittest.TestCase):
     def test_ci_enforced_not_local_is_harmful(self) -> None:
         harmful, stricter = compute_drift(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,21 @@ jobs:
       - name: Check for drift
         run: git diff --exit-code docs/openapi-snapshot.json
 
+  dockerfile-base-pin:
+    name: Dockerfile base-image pin gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Enforce Base Image Pinning (tech-decisions.md § Base Image Pinning, #735/#744)
+        # Every Dockerfile FROM must be digest-pinned AND carry the matching
+        # distro upgrade. The checker is stdlib-only (no deps to install). This
+        # job mirrors the `dockerfile-base-pin` pre-commit hook; the sync-drift
+        # gate classifies the kind so the two sides cannot drift apart.
+        run: python3 .claude/lib/check_dockerfile_base_pin.py Dockerfile
+
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate
     runs-on: ubuntu-latest
@@ -62,6 +77,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Run .claude/lib unit tests
+        # Exercise the reusable charter-enforcement libs (pre_commit_ci_sync.py,
+        # check_dockerfile_base_pin.py) and their tests. unittest-based + stdlib
+        # only, so no dependency install is needed. testpaths=["tests"] in
+        # pyproject excludes .claude from the app `check` job, so this is their
+        # dedicated CI home (closes the pre-existing gap that they ran nowhere).
+        run: python3 -m unittest discover -s .claude/lib/tests -p 'test_*.py'
       - name: Verify pre-commit config mirrors CI-enforced checks (#327)
         # Fails if a check the QUALITY-GATE CI workflows enforce
         # (ruff/mypy/pytest/actionlint/…) is missing from .pre-commit-config.yaml,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,21 @@ repos:
         args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
         files: ^(CLAUDE\.md|docs/.*\.md|\.claude/team/charter\.md)$
 
+  # Charter-prose→code gate (noorinalabs-main#735, rolled out here by #744). Runs
+  # `.claude/lib/check_dockerfile_base_pin.py` over this repo's Dockerfile,
+  # mirroring the `dockerfile-base-pin` CI job in ci.yml (the sync-drift gate
+  # classifies the `dockerfile-base-pin` kind, so this mirror is mandatory, not
+  # optional). Commit-stage (a cheap static scan). `files:` scopes which paths
+  # are candidates; the check itself self-filters (a scratch/exempt FROM passes).
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+        language: system
+        files: ((^|/)Dockerfile(\.[^/]+)?$|\.dockerfile$)
+        pass_filenames: true
+
   # Heavier checks run at pre-push (mirror CI's pytest job + the strict mypy from
   # `make check`). Run as `local`/`system` hooks via `uv run` so the pinned
   # tools from uv.lock are used and never drift from CI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@
 # (us#157). This digest ships 3.5.6-1~deb13u2, the Debian backport that fixes it.
 FROM python:3.12-slim@sha256:a39549e211a16149edf74e5fdc9ef03a6767e46cd987c5048b6659b6c9904c94 AS base
 
+# `apt-get -y upgrade` closes the *within-tag* package-drift failure mode the
+# digest pin alone cannot: the pinned manifest freezes the tag, but its OS
+# packages still accrue published CVEs between re-pins, so we upgrade to the
+# distro's current backports at build time (tech-decisions.md § Base Image
+# Pinning; enforced by .claude/lib/check_dockerfile_base_pin.py).
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get install -y --no-install-recommends gcc libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**Reviewers:** Mateo Salazar, Anya Kowalczyk (user-service roster)

## Summary

User-service slice of meta-issue #744 — rolls the noorinalabs-main#735 **Base Image Pinning** charter-prose→code gate into this image-building repo, same reusable-template pattern as `pre_commit_ci_sync.py` (#684).

## What changed

- **Checker + test copied in** from canonical noorinalabs-main: `.claude/lib/check_dockerfile_base_pin.py` (+ `tests/test_check_dockerfile_base_pin.py`). Stdlib-only.
- **pre-commit**: new commit-stage `dockerfile-base-pin` hook over Dockerfiles.
- **CI** (`ci.yml`): new `Dockerfile base-image pin gate` job running the checker on `Dockerfile`.
- **Sync-drift gate**: classified the `dockerfile-base-pin` kind in this repo's `pre_commit_ci_sync.py` (+ test) so the gate DEMANDS the pre-commit↔CI mirror (the #684 contract — an un-classified CI check is a silent blind spot).
- **Real violation fixed-forward**: the `base` stage was digest-pinned but ran `apt-get update && install` with **no `apt-get upgrade`** — the within-tag OS-package-drift mode the digest pin alone can't close. Added `apt-get -y upgrade` per `tech-decisions.md § Base Image Pinning`.
- **`.claude/lib/tests` CI home**: a `Run .claude/lib unit tests` step in the sync-gate job (`python -m unittest`, stdlib only). `pyproject` `testpaths=["tests"]` had excluded them from the app `check` job, so the new checker test AND the pre-existing `pre_commit_ci_sync` test ran nowhere — now they do.

## Verification (local, all green)

- `check_dockerfile_base_pin.py Dockerfile` → OK (was 1 violation pre-fix).
- `pre_commit_ci_sync.py . --ci ci.yml --ci docs.yml` → no harmful drift.
- `.claude/lib/tests` → 41 tests OK. ruff lint/format clean, actionlint OK.
- pre-commit + pre-push hooks passed at commit/push time.

TechDebt: Enabling the `.claude/lib/tests` CI step also surfaces the pre-existing-but-unrun `pre_commit_ci_sync` test into CI for the first time (it passes). The broader "CI for `.claude/lib/tests`" concern mirrors isnad-graph#1123 and is incidentally closed here for user-service; no separate user-service issue is opened. The child's pre-push `mypy` still scopes to `src/` only (not `.claude/lib`), unlike the parent's `.claude/(hooks|lib|skills)` scope — left as-is to avoid scope-expanding this rollout.

Part of #744
